### PR TITLE
reinvent autoload for Chef so utils don't take 30 seconds to start up

### DIFF
--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -15,7 +15,6 @@
 
 require File.expand_path(File.dirname(__FILE__))+"/mu-load-murc.rb"
 require 'trollop'
-require 'chef'
 require 'json'
 require 'mu'
 

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -97,9 +97,10 @@ else
     end
   end
 end
+
 avail_nodes = []
 do_deploys.each { |muid|
-  mommacat = MU::MommaCat.new(muid)
+  mommacat = MU::MommaCat.new(muid, skip_resource_objects: true)
   mommacat.listNodes.each_pair { |nodename, server|
     id = server['instance_id']
     server['conf']["platform"] = "linux" if !server['conf'].has_key?("platform")
@@ -108,6 +109,7 @@ do_deploys.each { |muid|
     avail_nodes << nodename
   }
 }
+pu
 if do_nodes.size > 0
   do_nodes.each { |node|
     if !avail_nodes.include?(node)

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -109,7 +109,7 @@ do_deploys.each { |muid|
     avail_nodes << nodename
   }
 }
-pu
+
 if do_nodes.size > 0
   do_nodes.each { |node|
     if !avail_nodes.include?(node)

--- a/modules/mu/cleanup.rb
+++ b/modules/mu/cleanup.rb
@@ -115,7 +115,7 @@ module MU
 
       # Scrub any residual Chef records with matching tags
       if !@onlycloud
-        MU::Groomers::Chef.loadChefLib
+        MU::Groomer::Chef.loadChefLib
         if File.exists?(Etc.getpwuid(Process.uid).dir+"/.chef/knife.rb")
           Chef::Config.from_file(Etc.getpwuid(Process.uid).dir+"/.chef/knife.rb")
         end

--- a/modules/mu/cleanup.rb
+++ b/modules/mu/cleanup.rb
@@ -115,6 +115,7 @@ module MU
 
       # Scrub any residual Chef records with matching tags
       if !@onlycloud
+        MU::Groomers::Chef.loadChefLib
         if File.exists?(Etc.getpwuid(Process.uid).dir+"/.chef/knife.rb")
           Chef::Config.from_file(Etc.getpwuid(Process.uid).dir+"/.chef/knife.rb")
         end

--- a/modules/mu/clouds/aws.rb
+++ b/modules/mu/clouds/aws.rb
@@ -343,10 +343,10 @@ module MU
             interval = 5 + Random.rand(4) - 2
             if retries < 5 and retries > 2
               debuglevel = MU::NOTICE
-              interval = 10 + Random.rand(6) - 3
+              interval = 20 + Random.rand(10) - 3
             elsif retries >= 5
               debuglevel = MU::WARN
-              interval = 20 + Random.rand(10) - 5
+              interval = 40 + Random.rand(15) - 5
             end
             MU.log "Got #{e.inspect} calling EC2's #{method_sym} in #{@region}, waiting #{interval.to_s}s and retrying. Args were: #{arguments}", debuglevel, details: caller
             sleep interval

--- a/modules/mu/clouds/aws/server.rb
+++ b/modules/mu/clouds/aws/server.rb
@@ -722,7 +722,7 @@ module MU
 
             nat_ssh_key, nat_ssh_user, nat_ssh_host, canonical_ip, ssh_user, ssh_key_name = getSSHConfig
             if subnet.private? and !nat_ssh_host and !MU::Cloud::AWS::VPC.haveRouteToInstance?(cloud_desc, region: @config['region'])
-              raise MuError, "#{node} is in a private subnet, but has no NAT host configured, and I have no other route to it"
+              raise MuError, "#{node} is in a private subnet (#{subnet}), but has no NAT host configured, and I have no other route to it"
             end
 
             # If we've asked for additional subnets (and this @config is not a

--- a/modules/mu/clouds/aws/vpc.rb
+++ b/modules/mu/clouds/aws/vpc.rb
@@ -521,6 +521,7 @@ module MU
           if !@config.nil? and @config.has_key?("subnets")
             @config['subnets'].each { |subnet|
               subnet['mu_name'] = @mu_name+"-"+subnet['name'] if !subnet.has_key?("mu_name")
+              subnet['region'] = @config['region']
               resp.data.subnets.each { |desc|
                 if desc.cidr_block == subnet["ip_block"]
                   subnet["tags"] = MU.structToHash(desc.tags)
@@ -540,6 +541,7 @@ module MU
               subnet['mu_name'] = @mu_name+"-"+subnet['name']
               subnet["tags"] = MU.structToHash(desc.tags)
               subnet["cloud_id"] = desc.subnet_id
+              subnet['region'] = @config['region']
               @subnets << MU::Cloud::AWS::VPC::Subnet.new(self, subnet)
             }
           end
@@ -1112,7 +1114,7 @@ module MU
             )
             resp.route_tables.each { |route_table|
               route_table.routes.each { |route|
-                if route.destination_cidr_block =="0.0.0.0/0"
+                if route.destination_cidr_block == "0.0.0.0/0"
                   return true if !route.instance_id.nil?
                   return false if !route.gateway_id.nil?
                 end

--- a/modules/mu/config.rb
+++ b/modules/mu/config.rb
@@ -631,7 +631,12 @@ module MU
 
         case vpc_block['subnet_pref']
           when "public"
-            vpc_block.merge!(public_subnets[rand(public_subnets.length)])
+            if !public_subnets.nil? and public_subnets.size > 0
+              vpc_block.merge!(public_subnets[rand(public_subnets.length)])
+            else
+              MU.log "Public subnet requested for #{parent_name}, but none found in #{vpc_block}", MU::ERR
+              return false
+            end
           when "private"
             vpc_block.merge!(private_subnets[rand(private_subnets.length)])
             if !is_sibling

--- a/modules/mu/config.rb
+++ b/modules/mu/config.rb
@@ -18,12 +18,6 @@ require 'erb'
 require 'pp'
 require 'json-schema'
 require 'net/http'
-gem "chef"
-autoload :Chef, 'chef'
-gem "knife-windows"
-gem "chef-vault"
-autoload :Chef, 'chef-vault'
-autoload :ChefVault, 'chef-vault'
 autoload :GraphViz, 'graphviz'
 
 module MU
@@ -719,7 +713,10 @@ module MU
               "vault" => server['windows_auth_vault']['vault'],
               "item" => server['windows_auth_vault']['item']
           }
-          item = ChefVault::Item.load(server['windows_auth_vault']['vault'], server['windows_auth_vault']['item'])
+          item = groomclass.getSecret(
+            vault: server['windows_auth_vault']['vault'],
+            item: server['windows_auth_vault']['item']
+          )
           ["password_field", "ec2config_password_field", "sshd_password_field"].each { |field|
             if !item.has_key?(server['windows_auth_vault'][field])
               MU.log "No value named #{field} in Chef Vault #{server['windows_auth_vault']['vault']}:#{server['windows_auth_vault']['item']}, will use a generated password.", MU::NOTICE
@@ -730,10 +727,10 @@ module MU
         # Check all of the non-special ones while we're at it
         server['vault_access'].each { |v|
           next if v['vault'] == "splunk" and v['item'] == "admin_user"
-          item = ChefVault::Item.load(v['vault'], v['item'])
+          item = groomclass.getSecret(vault: v['vault'], item: v['item'])
         }
-      rescue ChefVault::Exceptions::KeysNotFound => e
-        MU.log "Can't load a Chef Vault I was configured to use. Does it exist?", MU::ERR, details: e.inspect
+      rescue MuError
+        MU.log "Can't load a Chef Vault I was configured to use. Does it exist?", MU::ERR
         ok = false
       end
       return ok
@@ -1272,19 +1269,19 @@ module MU
         end
 
         if db['auth_vault'] && !db['auth_vault'].empty?
+          groomclass = MU::Groomer.loadGroomer(db['groomer'])
           if db['password']
             MU.log "Database password and database auth_vault can't both be used.", MU::ERR
             ok = false
           end
 
           begin
-            item = ChefVault::Item.load(db['auth_vault']['vault'], db['auth_vault']['item'])
+            item = groomclass.getSecret(vault: db['auth_vault']['vault'], item: db['auth_vault']['item'])
             if !item.has_key?(db['auth_vault']['password_field'])
               MU.log "No value named password_field in Chef Vault #{db['auth_vault']['vault']}:#{db['auth_vault']['item']}, will use an auto generated password.", MU::NOTICE
               db['auth_vault'].delete(field)
             end
-          rescue ChefVault::Exceptions::KeysNotFound => e
-            MU.log "Can't load the Chef Vault '#{db['auth_vault']['vault']}' I was configured to use. Does it exist?", MU::ERR, details: e.inspect
+          rescue MuError
             ok = false
           end
         end

--- a/modules/mu/groomers/chef.rb
+++ b/modules/mu/groomers/chef.rb
@@ -41,20 +41,25 @@ module MU
       def self.loadChefLib(user = MU.mu_user, env = "dev")
         if !@chefloaded
           MU.log "Loading Chef libraries..."
-#          pp caller
           start = Time.now
           require 'chef'
+          require 'chef/api_client_v1'
           require 'chef/knife'
           require 'chef/knife/ssh'
           require 'chef/knife/bootstrap'
           require 'chef/knife/bootstrap_windows_ssh'
+          require 'chef/knife/node_delete'
+          require 'chef/knife/client_delete'
+          require 'chef/knife/data_bag_delete'
           require 'chef-vault'
+          require 'chef-vault/item'
           if File.exists?("#{Etc.getpwnam(user).dir}/.chef/knife.rb")
             MU.log "Loading Chef configuration from #{Etc.getpwnam(user).dir}/.chef/knife.rb", MU::DEBUG
             ::Chef::Config.from_file("#{Etc.getpwnam(user).dir}/.chef/knife.rb")
           end
           ::Chef::Config[:chef_server_url] = "https://#{MU.mu_public_addr}/organizations/#{MU.chef_user}"
           ::Chef::Config[:environment] = env
+          ::Chef::Config[:yes] = true
           @chefloaded = true
           MU.log "Chef libraries loaded (took #{(Time.now-start).to_s} seconds)"
         end
@@ -101,6 +106,7 @@ module MU
 
       # Indicate whether our server has been bootstrapped with Chef
       def haveBootstrapped?
+        self.class.loadChefLib
         MU.log "Chef config", MU::DEBUG, details: ::Chef::Config.inspect
         nodelist = ::Chef::Node.list()
         nodelist.has_key?(@server.mu_name)
@@ -111,6 +117,7 @@ module MU
       # @param data [Hash]: Data to save
       # @param permissions [String]: An implementation-specific string describing what node or nodes should have access to this secret.
       def self.saveSecret(vault: @server.mu_name, item: nil, data: nil, permissions: nil)
+        loadChefLib
         if item.nil? or !item.is_a?(String)
           raise MuError, "item argument to saveSecret must be a String"
         end
@@ -119,12 +126,18 @@ module MU
         end
 
         cmd = "update"
-        exitstatus, output = MU::Groomer::Chef.knifeCmd("vault show '#{vault}' '#{item}' #{MU::Groomer::Chef.vault_opts} 2>&1 /dev/null")
-        cmd = "create" if exitstatus != 0
+        begin
+          MU.log "Checking for existence of #{vault} #{item}", MU::DEBUG, details: caller
+          ::ChefVault::Item.load(vault, item)
+        rescue ::ChefVault::Exceptions::KeysNotFound
+          cmd = "create"
+        end
         if permissions
-            MU::Groomer::Chef.knifeCmd("vault '#{cmd}' '#{vault}' '#{item}' '#{JSON.generate(data).gsub(/'/, '\\1')}' --search '#{permissions}' #{MU::Groomer::Chef.vault_opts}")
+          MU.log "knife vault #{cmd} #{vault} #{item} --search #{permissions}"
+          ::Chef::Knife.run(['vault', cmd, vault, item, JSON.generate(data).gsub(/'/, '\\1'), '--search', permissions])
         else
-            MU::Groomer::Chef.knifeCmd("vault '#{cmd}' '#{vault}' '#{item}' '#{JSON.generate(data).gsub(/'/, '\\1')}' #{MU::Groomer::Chef.vault_opts}")
+          MU.log "knife vault #{cmd} #{vault} #{item}"
+          ::Chef::Knife.run(['vault', cmd, vault, item, JSON.generate(data).gsub(/'/, '\\1')])
         end
       end
 
@@ -140,25 +153,25 @@ module MU
       # @param field [String]: OPTIONAL - A specific field within the item to return.
       # @return [Hash]
       def self.getSecret(vault: nil, item: nil, field: nil)
-
+        loadChefLib
         begin
-          item = ::ChefVault::Item.load(vault, item)
+          loaded = ::ChefVault::Item.load(vault, item)
         rescue ::ChefVault::Exceptions::KeysNotFound => e
           raise MuError, "Can't load the Chef Vault #{vault}:#{item}. Does it exist?"
         end
 
-        if item.nil?
+        if loaded.nil?
           raise MuError, "Failed to retrieve Vault #{vault}:#{item}"
         end
 
         if !field.nil?
-          if item.has_key?(field)
-            return item[field]
+          if loaded.has_key?(field)
+            return loaded[field]
           else
             raise MuError, "No such field in Vault #{vault}:#{item}"
           end
         else
-          return item
+          return loaded
         end
       end
 
@@ -170,9 +183,12 @@ module MU
       # Delete a Chef data bag / Vault
       # @param vault [String]: A repository of secrets to delete
       def self.deleteSecret(vault: nil)
+        loadChefLib
         raise MuError, "No vault specified, nothing to delete" if vault.nil?
         MU.log "Deleting vault #{vault}"
-        MU::Groomer::Chef.knifeCmd("data bag delete -y #{vault}")
+        knife_db = ::Chef::Knife::DataBagDelete.new(['data', 'bag', 'delete', vault])
+        knife_db.config[:yes] = true
+        knife_db.run
       end
 
       # see {MU::Groomer::Chef.deleteSecret}
@@ -185,6 +201,7 @@ module MU
       # @param purpose [String] = A string describing the purpose of this client run.
       # @param max_retries [Integer] = The maximum number of attempts at a successful run to make before giving up.
       def run(purpose: "Chef run", update_runlist: true, max_retries: 5)
+        self.class.loadChefLib
         if update_runlist and !@config['run_list'].nil?
           knifeAddToRunList(multiple: @config['run_list'])
         end
@@ -293,6 +310,7 @@ module MU
 
       # Bootstrap our server with Chef
       def bootstrap
+        self.class.loadChefLib
         createGenericHostSSLCert
         if !@config['cleaned_chef']
           begin
@@ -426,6 +444,7 @@ module MU
       # so that nodes can access this metadata.
       # @return [Hash]: The data synchronized.
       def saveDeployData
+        self.class.loadChefLib
         @server.describe(update_cache: true) # Make sure we're fresh
         saveChefMetadata
         begin
@@ -446,18 +465,33 @@ module MU
       # @param vaults_to_clean [Array<Hash>]: Some vaults to expunge
       # @param noop [Boolean]: Skip actual deletion, just state what we'd do
       def self.cleanup(node, vaults_to_clean = [], noop = false)
+        loadChefLib
         MU.log "Deleting Chef resources associated with #{node}"
         vaults_to_clean.each { |vault|
           MU::MommaCat.lock("vault-#{vault['vault']}", false, true)
           MU.log "knife vault remove #{vault['vault']} #{vault['item']} --search name:#{node}", MU::NOTICE
-          `#{MU::Groomer::Chef.knife} vault remove #{vault['vault']} #{vault['item']} --search name:#{node} 2>&1 > /dev/null` if !noop
+          ::Chef::Knife.run(['vault', 'remove', vault['vault'], vault['item'], "--search", "name:#{node}"]) if !noop
           MU::MommaCat.unlock("vault-#{vault['vault']}")
         }
+        MU.log "knife node delete #{node}"
+        if !noop
+          knife_nd = ::Chef::Knife::NodeDelete.new(['node', 'delete', node])
+          knife_nd.config[:yes] = true
+          begin
+            knife_nd.run
+          rescue Net::HTTPServerException
+          end
+        end
+        MU.log "knife client delete #{node}"
+        if !noop
+          knife_cd = ::Chef::Knife::ClientDelete.new(['client', 'delete', node])
+          knife_cd.config[:yes] = true
+          begin
+            knife_cd.run
+          rescue Net::HTTPServerException
+          end
+        end
 
-        MU.log "knife node delete -y #{node}"
-        `#{MU::Groomer::Chef.knife} node delete -y #{node}` if !noop
-        MU.log "knife client delete -y #{node}"
-        `#{MU::Groomer::Chef.knife} client delete -y #{node}` if !noop
         deleteSecret(vault: node) if !noop
         ["crt", "key", "csr"].each { |ext|
           if File.exists?("#{MU.mySSLDir}/#{node}.#{ext}")
@@ -471,6 +505,7 @@ module MU
 
       # Save common Mu attributes to this node's Chef node structure.
       def saveChefMetadata
+        self.class.loadChefLib
         nat_ssh_key, nat_ssh_user, nat_ssh_host, canonical_addr, ssh_user, ssh_key_name = @server.getSSHConfig
         MU.log "Saving #{@server.mu_name} Chef artifacts"
 
@@ -572,37 +607,15 @@ module MU
       end
 
       def grantSecretAccess(vault, item)
+        self.class.loadChefLib
         return if @secrets_granted["#{vault}:#{item}"]
         MU::MommaCat.lock("vault-#{vault}", false, true)
-        retries = 0
+        MU.log "Granting #{@server.mu_name} access to #{vault} #{item}"
         begin
-          retries += 1
-          exitstatus, output = knifeCmd("vault update #{vault} #{item} #{MU::Groomer::Chef.vault_opts} --search name:#{@server.mu_name}")
-          exitstatus, output = knifeCmd("vault show #{vault} #{item} clients -p clients -f yaml #{MU::Groomer::Chef.vault_opts} 2>&1")
-
-          if !output.match(/#{@server.mu_name}/)
-            MU.log "Didn't see #{@server.mu_name} in output of vault show #{vault} #{item}, trying again...", MU::WARN, details: output
-            if retries < 10
-              MU::MommaCat.unlock("vault-#{vault}")
-              sleep 5
-              redo
-            else
-              MU::MommaCat.unlock("vault-#{vault}")
-              raise MuError, "Unable to add node #{@server.mu_name} to #{vault} #{item}, aborting"
-            end
-          else
-            @secrets_semaphore.synchronize {
-              @secrets_granted["#{vault}:#{item}"] = true
-            }
-
-            MU.log "Granted #{@server.mu_name} access to #{vault} #{item} after #{retries} retries", MU::NOTICE
-            MU::MommaCat.unlock("vault-#{vault}")
-            return
-          end
-        ensure
-          MU::MommaCat.unlock("vault-#{vault}")
-        end while true
-
+          ::Chef::Knife.run(['vault', 'update', vault, item, "--search", "name:#{@server.mu_name}"])
+        rescue Exception => e
+          MU.log e.inspect, MU::ERR, details: caller
+        end
         MU::MommaCat.unlock("vault-#{vault}")
       end
 
@@ -697,6 +710,7 @@ module MU
       # @param multiple [Array<String>]: Add more than one run_list entry. Overrides rl_entry.
       # @return [void]
       def knifeAddToRunList(rl_entry = nil, type="role", ignore_missing: false, multiple: [])
+        self.class.loadChefLib
         return if rl_entry.nil? and multiple.size == 0
         if multiple.size == 0
           multiple = [rl_entry]

--- a/modules/mu/mommacat.rb
+++ b/modules/mu/mommacat.rb
@@ -1584,7 +1584,7 @@ MESSAGE_END
         first_ltr = @words.select { |word| word.match(/^#{seed[0]}/i) }
         word_one = first_ltr.shuffle.first
         # If we got a paired set that happen to match our letters, go with it
-        if !word_one.nil? and word_one.match(/-#{seed[1]}/)
+        if !word_one.nil? and word_one.match(/-#{seed[1]}/i)
           word_one, word_two = word_one.split(/-/)
         else
           second_ltr = @words.select { |word| word.match(/^#{seed[1]}/i) and !word.match(/-/i) }
@@ -2240,7 +2240,7 @@ MESSAGE_END
     end
 
 
-    @catwords = %w{abyssian acinonyx alley angora bastet bengal birman bobcat bobtail bombay burmese calico chartreux cheetah cheshire cornish-rex curl devon devon-rex dot egyptian-mau feline felix feral fuzzy ginger havana himilayan jaguar japanese-bobtail javanese kitty khao-manee leopard lion lynx maine-coon manx marmalade maru mau mittens moggy munchkin neko norwegian ocelot pallas panther patches paws persian peterbald phoebe polydactyl purr queen quick ragdoll roar russian-blue saber savannah scottish-fold sekhmet serengeti shorthair siamese siberian singapura snowshoe socks sphinx spot stray tabby tail tiger tom tonkinese tortoiseshell turkish-van tuxedo uncia whiskers wildcat yowl}
+    @catwords = %w{abyssian acinonyx alley angora bastet bengal birman bobcat bobtail bombay burmese calico chartreux cheetah cheshire cornish-rex curl devon devon-rex dot egyptian-mau feline felix feral fuzzy ginger havana himilayan jaguar japanese-bobtail javanese kitty khao-manee leopard lion lynx maine-coon manx marmalade maru mau mittens moggy munchkin neko norwegian ocelot pallas panther patches paws persian peterbald phoebe polydactyl purr queen quick ragdoll roar russian-blue saber savannah scottish-fold sekhmet serengeti shorthair siamese siberian singapura skogkatt snowshoe socks sphinx spot stray tabby tail tiger tom tonkinese tortoiseshell turkish-van tuxedo uncia whiskers wildcat yowl}
     @noncatwords = %w{alpha amber auburn azure beta brave bravo brawler charlie chocolate chrome cinnamon corinthian coyote crimson dancer danger dash delta don duet echo edge electric elite enigma eruption eureka fearless foxtrot galvanic gold grace grey horizon hulk hyperion illusion imperative india intercept ivory jade jaeger juliet kaleidoscope kilo lucky mammoth night nova november ocean olive oscar quiescent rhythm rogue romeo ronin royal tacit tango typhoon ultimatum ultra umber upward victor violet vivid vulcan watchman whirlwind wright xenon xray xylem yankee yearling yell yukon zeal zero zippy zodiac}
     @words = @catwords + @noncatwords
 

--- a/modules/mu/mommacat.rb
+++ b/modules/mu/mommacat.rb
@@ -137,6 +137,7 @@ module MU
     # @param ssh_private_key [String]: Required when creating a new deployment.
     # @param ssh_public_key [String]: SSH public key for authorized_hosts on clients.
     # @param verbose [Boolean]: Enable verbose log output.
+    # @param skip_resource_objects [Boolean]: Whether preload the cloud resource objects from this deploy. Can save load time for simple MommaCat tasks.
     # @param nocleanup [Boolean]: Skip automatic cleanup of failed resources
     # @param deployment_data [Hash]: Known deployment data.
     # @return [void]
@@ -151,6 +152,7 @@ module MU
                    verbose: false,
                    nocleanup: false,
                    set_context_to_me: true,
+                   skip_resource_objects: false,
                    deployment_data: deployment_data = Hash.new,
                    mu_user: "root"
     )
@@ -237,7 +239,7 @@ module MU
       # Initialize a MU::Cloud object for each resource belonging to this
       # deploy, IF it already exists, which is to say if we're loading an
       # existing deploy instead of creating a new one.
-      if !create and @deployment and @original_config
+      if !create and @deployment and @original_config and !skip_resource_objects
         MU::Cloud.resource_types.each_pair { |res_type, attrs|
           type = attrs[:cfg_plural]
           if @deployment.has_key?(type)

--- a/modules/mu/mommacat.rb
+++ b/modules/mu/mommacat.rb
@@ -1004,7 +1004,7 @@ module MU
                 straykitten = momma.findLitterMate(type: type, name: matches.first["name"], cloud_id: cloud_id)
               end
             else
-              straykitten = momma.findLitterMate(type: type, name: name, mu_name: mu_name)
+              straykitten = momma.findLitterMate(type: type, name: name, mu_name: mu_name, cloud_id: cloud_id)
             end
             next if straykitten.nil?
 
@@ -1049,6 +1049,8 @@ module MU
           regions.each { |r|
             next if cloud_descs[r].nil?
             cloud_descs[r].each_pair { |kitten_cloud_id, descriptor|
+puts "#{r}: #{kitten_cloud_id}"
+pp kittens.keys
               # We already have a MU::Cloud object for this guy, use it
               if kittens.has_key?(kitten_cloud_id)
                 matches << kitten[kitten_cloud_id]


### PR DESCRIPTION
Chef is too dopey to chase down its various submodules when you ask for a symbol underneath the top level, so I'd been opening the Chef class to insert autoload statements to pick up the slack. The act of reopening the Chef class was triggering the autoload of the actual Chef libraries right off the bat, which takes forever, thus mooting the point of using autoload in the first place. Which is why all of our utilities take an eternity to spin up, at least in FEMA land.

I implemented some homebrew lazy-loading in `MU::Groomers::Chef` to circumvent the problem entirely. Now utilities that don't need to invoke Chef libs for anything snap up almost instantly. For kicks, you also get these cute little messages when you do grab the Chef libs:

    Sep 30 16:02:15 - groomers/chef - Loading Chef libraries...
    Sep 30 16:02:37 - groomers/chef - Chef libraries loaded (took 21.90399 seconds)

I also factored out the direct references to Chef's libraries in `MU::Config`, which shouldn't have been there in the first place. They were around for vault-accessibility tests, which can be done using `.getSecret` from whatever Groomer is appropriate. @amirahav this includes your checks under the database section, so please give this a quick test with your stuff to make sure it'll still handle your various edge cases correctly.

Finally, I got rid of the remaining calls to knife as an external process, e.g. for managing vaults, to save us that particular startup penalty.

Testing this doesn't need to be too deep. Make sure you can bring up a node or two, that chef works normally on them when re-grooming, and that cleanup isn't broken. I expect to merge this tomorrow.