### PR TITLE
knife-windows 1.4.0

### DIFF
--- a/install/knife-windows-cygwin-1.4.0.patch
+++ b/install/knife-windows-cygwin-1.4.0.patch
@@ -1,0 +1,147 @@
+--- knife-windows-1.4.0/lib/chef/knife/bootstrap/windows-chef-client-msi.erb	2016-04-12 01:00:36.993000454 -0400
++++ knife-windows-1.4.0/lib/chef/knife/bootstrap/windows-chef-client-msi_patched.erb	2016-04-12 01:17:43.000000000 -0400
+@@ -167,6 +167,17 @@
+ 
+   <%= install_chef %>
+ 
++   SET LookForFile="c:\opscode\chef\bin\chef-client.bat"
++   @echo off
++
++   :CheckForFile
++   IF EXIST %LookForFile% GOTO FoundIt
++   c:\Windows\System32\timeout.exe /t 30
++   GOTO CheckForFile
++
++   :FoundIt
++   @echo on
++
+   @if ERRORLEVEL 1 (
+       echo Chef-client package failed to install with status code !ERRORLEVEL!. > "&2"
+       echo See installation log for additional detail: %CHEF_CLIENT_MSI_LOG_PATH%. > "&2"
+--- knife-windows-1.4.0/lib/chef/knife/bootstrap_windows_base.rb	2016-04-12 10:33:50.000000000 -0400
++++ knife-windows-1.4.0/lib/chef/knife/bootstrap_windows_base_patched.rb	2016-04-12 10:20:11.000000000 -0400
+@@ -335,7 +335,11 @@
+         # we have to run the remote commands in 2047 char chunks
+         create_bootstrap_bat_command do |command_chunk|
+           begin
+-            render_command_result = run_command(command_chunk)
++            render_command = command_chunk
++            if locate_config_value(:cygwin)
++              render_command = %q!cd $TEMP && !+command_chunk
++            end
++            render_command_result = run_command(render_command)
+             ui.error("Batch render command returned #{render_command_result}") if render_command_result != 0
+             render_command_result
+           rescue SystemExit => e
+@@ -357,11 +361,20 @@
+       end
+ 
+       def bootstrap_command
++        if locate_config_value(:cygwin)
++          @bootstrap_command ||= "cd $TEMP && cmd.exe /C #{bootstrap_bat_file}"
++        else
+         @bootstrap_command ||= "cmd.exe /C #{bootstrap_bat_file}"
+       end
++        @bootstrap_command
++      end
+ 
+       def bootstrap_render_banner_command(chunk_num)
+-        "cmd.exe /C echo Rendering #{bootstrap_bat_file} chunk #{chunk_num}"
++        if locate_config_value(:cygwin)
++          return "echo 'Rendering #{bootstrap_bat_file} chunk #{chunk_num}'"
++        else
++          return "cmd.exe /C echo Rendering #{bootstrap_bat_file} chunk #{chunk_num}"
++        end
+       end
+ 
+       def escape_windows_batch_characters(line)
+@@ -374,11 +387,18 @@
+         bootstrap_bat = ""
+         banner = bootstrap_render_banner_command(chunk_num += 1)
+         render_template(load_template(config[:bootstrap_template])).each_line do |line|
+-          escape_windows_batch_characters(line)
+           # We are guaranteed to have a prefix "banner" command that echo's chunk number.  We can
+           # confidently prefix every actual command with &&.
+           # TODO: Why does ^\n&& work directly through the commandline but not through SOAP?
++          if locate_config_value(:cygwin)
++            render_line = ""
++            if !line.nil? and !line.chomp.strip.nil?
++              render_line = " && echo '#{line.chomp.strip.gsub(/'/, '\'\\\\\1\'\'')}' >> #{bootstrap_bat_file}"
++            end
++          else
++            escape_windows_batch_characters(line)
+           render_line = " && >> #{bootstrap_bat_file} (echo.#{line.chomp.strip})"
++          end
+           # Windows commands are limited to 8191 characters for machines running XP or higher but
+           # this includes the length of environment variables after they have been expanded.
+           # Since we don't actually know how long %TEMP% (and it's used twice - once in the banner
+@@ -405,8 +425,12 @@
+       end
+ 
+       def bootstrap_bat_file
++        if locate_config_value(:cygwin)
++          @bootstrap_bat_file ||= "\"bootstrap-#{Process.pid}-#{Time.now.to_i}.bat\""
++        else
+         @bootstrap_bat_file ||= "\"%TEMP%\\bootstrap-#{Process.pid}-#{Time.now.to_i}.bat\""
+       end
++      end
+ 
+       def warn_chef_config_secret_key
+         ui.info "* " * 40
+@@ -426,11 +450,14 @@
+       # to whatever the target system is.  We assume that we are only bootstrapping 1 node at a time
+       # so we don't need to worry about multipe responses from this command.
+       def set_target_architecture(bootstrap_architecture)
++        if locate_config_value(:cygwin)
++        else
+         session_results = relay_winrm_command("echo %PROCESSOR_ARCHITECTURE%")
+         if session_results.empty? || session_results[0].stdout.strip.empty?
+           raise "Response to 'echo %PROCESSOR_ARCHITECTURE%' command was invalid: #{session_results}"
+         end
+         current_architecture = session_results[0].stdout.strip == "X86" ? :i386 : :x86_64
++        end
+ 
+         if bootstrap_architecture.nil?
+           architecture = current_architecture
+--- knife-windows-1.4.0/lib/chef/knife/bootstrap_windows_ssh.rb	2016-04-12 01:00:36.994000454 -0400
++++ knife-windows-1.4.0/lib/chef/knife/bootstrap_windows_ssh_patched.rb	2016-04-12 01:14:37.000000000 -0400
+@@ -91,12 +91,24 @@
+         :boolean => true,
+         :default => true
+ 
++      option :cygwin,
++        :long => "--[no-]cygwin",
++        :short => "-c",
++        :description => "Assume that we have Cygwin (and a bash shell) at the client end.",
++        :boolean => true,
++        :default => false
++
+       def run
+         bootstrap
+       end
+ 
+       def run_command(command = '')
+         ssh = Chef::Knife::Ssh.new
++        if locate_config_value(:cygwin)
++          # Harvest crucial env variables that don't exist by default in
++          # Cygwin shells.
++          command = %q{export CYGWIN=nodosfilewarning && for __dir in /proc/registry/HKEY_LOCAL_MACHINE/SYSTEM/CurrentControlSet/Control/Session\ Manager/Environment;do cd "$__dir";for __var in *;do __var=`echo $__var | tr "[a-z]" "[A-Z]"` ; test -z "${!__var}" && export $__var="`cat $__var`" >/dev/null 2>&1;done;/bin/true;done && export TEMP="$SYSTEMROOT/TEMP" && export TMP="$TEMP"} + " && cd && " + command
++        end
+         ssh.name_args = [ server_name, command ]
+         ssh.config[:ssh_user] = locate_config_value(:ssh_user)
+         ssh.config[:ssh_password] = locate_config_value(:ssh_password)
+--- knife-windows-1.4.0/lib/chef/knife/core/windows_bootstrap_context.rb	2016-04-12 01:00:36.994000454 -0400
++++ knife-windows-1.4.0/lib/chef/knife/core/windows_bootstrap_context_patched.rb	2016-04-12 01:03:35.000000000 -0400
+@@ -285,7 +285,12 @@
+             url += "&pv=#{machine_os}" unless machine_os.nil?
+             url += "&m=#{machine_arch}" unless machine_arch.nil?
+             url += "&DownloadContext=#{download_context}" unless download_context.nil?
++            if !@config[:bootstrap_version].nil? and @config[:bootstrap_version]
++              require 'uri'
++              url += "&v=#{URI.escape(@config[:bootstrap_version])}"
++            else
+             url += latest_current_windows_chef_version_query
++            end
+           else
+             @config[:msi_url]
+           end

--- a/install/mu_setup
+++ b/install/mu_setup
@@ -701,7 +701,7 @@ chef_server_ctl()
 ## Patch knife-windows to deal with Cygwin
 patch_knife_windows()
 {
-  kw_version="1.1.4"
+  kw_version="1.4.0"
 
   for rubydir in $RUBY_INSTALL_DIR /opt/chef/embedded;do
     if [ -d "$rubydir/lib/ruby/gems" ];then

--- a/modules/Gemfile
+++ b/modules/Gemfile
@@ -16,10 +16,10 @@ source "https://rubygems.org"
 gem 'yard'
 gem 'ruby-graphviz', "~> 1.2.2"
 gem 'chef', "~> 12.8.1"
-gem "aws-sdk-core", "~> 2.2.26"
+gem "aws-sdk-core", "~> 2.2.34"
 gem 'simple-password-gen'
 gem 'trollop', "~> 2.1.2"
-gem 'knife-windows', '1.1.4'
+gem 'knife-windows', '1.4.0'
 gem 'fileutils'
 gem 'json-schema'
 gem 'colorize'
@@ -31,7 +31,7 @@ gem 'pg'
 gem 'mysql'
 gem 'ruby-wmi'
 gem 'chef-vault', "~> 2.8.0"
-gem 'net-ssh', "~> 3.0.2"
+gem 'net-ssh', "~> 3.1.1"
 gem 'netaddr'
 gem 'nokogiri', "~> 1.6.7.2"
 gem 'celluloid', "= 0.16.0"

--- a/modules/Gemfile.lock
+++ b/modules/Gemfile.lock
@@ -2,9 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk-core (2.2.28)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    berkshelf (4.3.0)
+    berkshelf (4.3.2)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
       buff-config (~> 1.0)
@@ -97,14 +97,14 @@ GEM
     hitimes (1.2.3)
     httpclient (2.7.1)
     ipaddress (0.8.3)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.3)
     json-schema (2.6.1)
       addressable (~> 2.3.8)
-    knife-windows (1.1.4)
-      nokogiri
-      winrm (~> 1.5)
-      winrm-s (~> 0.3.4)
+    json_pure (1.8.3)
+    knife-windows (1.4.0)
+      winrm (~> 1.7)
     libyajl2 (1.2.0)
     little-plugger (1.1.4)
     logging (2.1.0)
@@ -128,7 +128,7 @@ GEM
     net-ldap (0.14.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.0.2)
+    net-ssh (3.1.1)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.2.1)
@@ -142,7 +142,7 @@ GEM
     nori (2.6.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.12.1)
+    ohai (8.14.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -151,7 +151,7 @@ GEM
       mixlib-config (~> 2.0)
       mixlib-log
       mixlib-shellout (~> 2.0)
-      plist
+      plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     pg (0.18.4)
@@ -204,7 +204,7 @@ GEM
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
     semverse (1.2.1)
-    serverspec (2.31.0)
+    serverspec (2.31.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
@@ -214,9 +214,9 @@ GEM
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
-    specinfra (2.54.1)
+    specinfra (2.56.1)
       net-scp
-      net-ssh (>= 2.7, < 3.1)
+      net-ssh (>= 2.7, < 4.0)
       net-telnet
       sfl
     syslog-logger (1.6.8)
@@ -233,7 +233,7 @@ GEM
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)
-    winrm (1.7.2)
+    winrm (1.7.3)
       builder (>= 2.1.2)
       gssapi (~> 1.2)
       gyoku (~> 1.0)
@@ -241,8 +241,6 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0)
-    winrm-s (0.3.6)
-      winrm (~> 1.3, >= 1.3.6)
     wmi-lite (1.0.0)
     yard (0.8.7.6)
 
@@ -250,7 +248,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-core (~> 2.2.26)
+  aws-sdk-core (~> 2.2.34)
   berkshelf
   celluloid (= 0.16.0)
   chef (~> 12.8.1)
@@ -259,10 +257,10 @@ DEPENDENCIES
   colorize
   fileutils
   json-schema
-  knife-windows (= 1.1.4)
+  knife-windows (= 1.4.0)
   mysql
   net-ldap
-  net-ssh (~> 3.0.2)
+  net-ssh (~> 3.1.1)
   netaddr
   nokogiri (~> 1.6.7.2)
   pg

--- a/modules/mu/userdata/windows.erb
+++ b/modules/mu/userdata/windows.erb
@@ -88,22 +88,6 @@
 		log "Setting Windows Update parameters in registry"
 		Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update" -Name AUOptions -Value 3
 
-		# This is a crappy workaround because even when we set all the right permissions/privileges ssh still doesn't always work, so we're removing on every instance
-#		If (!(Test-Path "c:/$instanceid")){
-#			log "I don't see c:/$instanceid"
-#			Disable-SSHD
-#		}
-
-		# even when we set all the right permissions/privileges ssh still doesn't always work, so we're removing if the user that installed ssh service changed
-#		if (!(Get-WmiObject win32_computersystem).partofdomain){
-#			if ((Test-Path $cygwin_dir\sshd_installed_by.txt) -and ((Get-Content $cygwin_dir\sshd_installed_by.txt) -ne $admin_username)){
-#				if ($username -ne "system"){
-#					log "I am not in a domain, my admin user is $admin_username, and sshd was last installed by $(Get-Content $cygwin_dir\sshd_installed_by.txt)"
-#					Disable-SSHD
-#				}
-#			}
-#		}
-
 		If (!(Test-Path "$cygwin_dir/Cygwin.bat")){
 			If (!(Test-Path $env:Temp/setup-x86_64.exe)){
 				Invoke-WebRequest -Uri "http://cygwin.com/setup-x86_64.exe" -OutFile $env:Temp/setup-x86_64.exe
@@ -194,13 +178,41 @@
 		}
 
 		If (!(Test-Path "c:\opscode\chef\embedded\bin\ruby.exe")){
+      $install_chef = $true
+		} else {
+      if (removeChef("HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*") -or removeChef("HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*")){
+        $install_chef = $true
+      } else {
+        $install_chef = $false
+      }
+    }
+
+    function removeChef($location){
+      $install_chef = $false
+      $my_chef = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).DisplayName
+      if ($my_chef) {
+        if ($my_chef -match '<%= MU.chefVersion %>') {
+          $install_chef = $false
+        } else{
+          log "Uninstalling Chef"
+          $uninstall_string = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).UninstallString
+          $uninstall_string = ($uninstall_string -Replace "msiexec.exe","" -Replace "/I","" -Replace "/X","").Trim()
+          start-process "msiexec.exe" -arg "/X $uninstall_string /qn" -Wait
+          $install_chef = $true
+        }
+      }
+      
+      return $install_chef
+    }
+
+		If ($install_chef){
 			log "Installing Chef"
-			If (!(Test-Path $env:Temp/chef-installer.msi)){
+			If (!(Test-Path $env:Temp/chef-installer-<%= MU.chefVersion %>.msi)){
 				log "Downloading Chef installer"
-				Invoke-WebRequest -Uri "https://www.chef.io/chef/download?p=windows&pv=2012&m=x86_64&v=<%= MU.chefVersion %>" -OutFile $env:Temp/chef-installer.msi
+				Invoke-WebRequest -Uri "https://www.chef.io/chef/download?p=windows&pv=2012&m=x86_64&v=<%= MU.chefVersion %>" -OutFile $env:Temp/chef-installer-<%= MU.chefVersion %>.msi
 			}
 			log "Running Chef installer"
-			(Start-Process -FilePath msiexec -ArgumentList "/i $env:Temp\chef-installer.msi ALLUSERS=1 /le $env:Temp\chef-client-install.log /qn" -Wait -Passthru).ExitCode
+			(Start-Process -FilePath msiexec -ArgumentList "/i $env:Temp\chef-installer-<%= MU.chefVersion %>.msi ALLUSERS=1 /le $env:Temp\chef-client-install.log /qn" -Wait -Passthru).ExitCode
 			Set-Content "c:/mu_installed_chef" "yup"
 		}
 

--- a/modules/mu/userdata/windows.erb
+++ b/modules/mu/userdata/windows.erb
@@ -6,6 +6,7 @@
 	$base_dir = 'c:/bin'
 	$cygwin_dir = "$base_dir/cygwin"
 	$username = (whoami).Split('\')[1]
+	$WebClient = New-Object System.Net.WebClient
 
 	function log
 	{
@@ -72,7 +73,7 @@
 			mkdir c:/Users/$admin_username/Documents/WindowsPowerShell/Modules
 		}
 
-		Invoke-WebRequest -Uri "https://s3.amazonaws.com/cap-public/PSWindowsUpdate.zip" -OutFile $env:Temp/PSWindowsUpdate.zip
+		$WebClient.DownloadFile("https://s3.amazonaws.com/cap-public/PSWindowsUpdate.zip","$env:Temp/PSWindowsUpdate.zip")
 		Add-Type -A 'System.IO.Compression.FileSystem'
 
 		If (!(Test-Path c:/windows/System32/WindowsPowerShell/v1.0/Modules/PSWindowsUpdate)){
@@ -90,12 +91,12 @@
 
 		If (!(Test-Path "$cygwin_dir/Cygwin.bat")){
 			If (!(Test-Path $env:Temp/setup-x86_64.exe)){
-				Invoke-WebRequest -Uri "http://cygwin.com/setup-x86_64.exe" -OutFile $env:Temp/setup-x86_64.exe
+				$WebClient.DownloadFile("http://cygwin.com/setup-x86_64.exe","$env:Temp/setup-x86_64.exe")
 			}
 
 			If (!(Test-Path $env:Temp/cygwin.zip)){
 				log "Downloading Cygwin packages"
-				Invoke-WebRequest -Uri "https://s3.amazonaws.com/cap-public/cygwin_20150531.zip" -OutFile $env:Temp/cygwin.zip
+				$WebClient.DownloadFile("https://s3.amazonaws.com/cap-public/cygwin_20150531.zip","$env:Temp/cygwin.zip")
 			}
 
 			Add-Type -A 'System.IO.Compression.FileSystem'
@@ -161,7 +162,7 @@
 		If (!(Test-Path "$python_path\python.exe")){
 			If (!(Test-Path $env:Temp/python-2.7.9.msi)){
 				log "Downloading Python installer"
-				Invoke-WebRequest -Uri "https://www.python.org/ftp/python/2.7.9/python-2.7.9.msi" -OutFile $env:Temp/python-2.7.9.msi
+				$WebClient.DownloadFile("https://www.python.org/ftp/python/2.7.9/python-2.7.9.msi","$env:Temp/python-2.7.9.msi")
 			}
 			log "Running Python installer"
 			(Start-Process -FilePath msiexec -ArgumentList "/i $env:Temp\python-2.7.9.msi /qn ALLUSERS=1 TARGETDIR=$python_path" -Wait -Passthru).ExitCode
@@ -170,46 +171,48 @@
 		If (!(Test-Path "$python_path\Scripts\aws.cmd")){
 			If (!(Test-Path $env:Temp/get-pip.py)){
 				log "Downloading get-pip.py"
-				Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile $env:Temp/get-pip.py
+				$WebClient.DownloadFile("https://bootstrap.pypa.io/get-pip.py","$env:Temp/get-pip.py")
 			}
 			python $env:Temp/get-pip.py
 			log "Running pip install awscli"
 			pip install awscli
 		}
 
-		If (!(Test-Path "c:\opscode\chef\embedded\bin\ruby.exe")){
-      $install_chef = $true
-		} else {
-      if (removeChef("HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*") -or removeChef("HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*")){
-        $install_chef = $true
-      } else {
-        $install_chef = $false
-      }
-    }
+		function removeChef($location){
+			$install_chef = $false
+			$my_chef = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).DisplayName
+			if ($my_chef) {
+				if ($my_chef -match '<%= MU.chefVersion %>'.split('-')[0]) {
+					$install_chef = $false
+				} else{
+					log "Uninstalling Chef"
+					$uninstall_string = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).UninstallString
+					$uninstall_string = ($uninstall_string -Replace "msiexec.exe","" -Replace "/I","" -Replace "/X","").Trim()
+					start-process "msiexec.exe" -arg "/X $uninstall_string /qn" -Wait
+					$install_chef = $true
+				}
+			}
+			
+			return $install_chef
+		}
 
-    function removeChef($location){
-      $install_chef = $false
-      $my_chef = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).DisplayName
-      if ($my_chef) {
-        if ($my_chef -match '<%= MU.chefVersion %>') {
-          $install_chef = $false
-        } else{
-          log "Uninstalling Chef"
-          $uninstall_string = (Get-ItemProperty $location | Where-Object {$_.DisplayName -like "chef client*"}).UninstallString
-          $uninstall_string = ($uninstall_string -Replace "msiexec.exe","" -Replace "/I","" -Replace "/X","").Trim()
-          start-process "msiexec.exe" -arg "/X $uninstall_string /qn" -Wait
-          $install_chef = $true
-        }
-      }
-      
-      return $install_chef
-    }
+		If (!(Test-Path "c:\opscode\chef\embedded\bin\ruby.exe")){
+			$install_chef = $true
+		} else {
+			if (removeChef("HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*")){
+				$install_chef = $true
+			} elseif (removeChef("HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*")) {
+				$install_chef = $true
+			} else {
+				$install_chef = $false
+			}
+		}
 
 		If ($install_chef){
 			log "Installing Chef"
 			If (!(Test-Path $env:Temp/chef-installer-<%= MU.chefVersion %>.msi)){
 				log "Downloading Chef installer"
-				Invoke-WebRequest -Uri "https://www.chef.io/chef/download?p=windows&pv=2012&m=x86_64&v=<%= MU.chefVersion %>" -OutFile $env:Temp/chef-installer-<%= MU.chefVersion %>.msi
+				$WebClient.DownloadFile("https://www.chef.io/chef/download?p=windows&pv=2012&m=x86_64&v=<%= MU.chefVersion %>","$env:Temp/chef-installer-<%= MU.chefVersion %>.msi")
 			}
 			log "Running Chef installer"
 			(Start-Process -FilePath msiexec -ArgumentList "/i $env:Temp\chef-installer-<%= MU.chefVersion %>.msi ALLUSERS=1 /le $env:Temp\chef-client-install.log /qn" -Wait -Passthru).ExitCode
@@ -221,9 +224,9 @@
 			log "Applying Windows updates"
 			Import-Module PSWindowsUpdate
 			Get-WUInstall -AcceptAll -IgnoreReboot
-      Start-Sleep -s 60
+			Start-Sleep -s 60
 			If (Test-Path "HKLM:/SOFTWARE/Microsoft/Windows/CurrentVersion/WindowsUpdate/Auto Update/RebootRequired"){
-        log "Registry fiddling says I need a reboot"
+				log "Registry fiddling says I need a reboot"
 				$need_reboot = $TRUE
 			}
 		}
@@ -258,10 +261,10 @@
 		New-Item $cygwin_dir/home/$admin_username/.ssh/authorized_keys -type file -force -value "<%= $mu.deploySSHKey %>"
 <% end %>
 
-    if((Get-WURebootStatus -Silent) -eq $true){
-      log "Get-WURebootStatus telling me I need a reboot for real"
+		if((Get-WURebootStatus -Silent) -eq $true){
+			log "Get-WURebootStatus telling me I need a reboot for real"
 			$need_reboot = $TRUE
-    }
+		}
 
 		if ($need_reboot){
 			log "----- REBOOT -----"
@@ -274,7 +277,7 @@
 			log "Enabling sshd service"
 			sleep 30; Start-Service sshd
 			Set-Service sshd -startuptype "Automatic"
-      Get-WUInstall -AcceptAll -AutoReboot
+			Get-WUInstall -AcceptAll -AutoReboot
 
 			$url = 'https://<%= $mu.publicIP %>:2260'
 			log "Calling home to $url"


### PR DESCRIPTION
knife-windows 1.1.4 ended up being problematic - files in the installed gem have a Windows line ending which cause the patch to fail.
This patches knife-windows 1.4.0 instead, which uses Unix line endings.
(yes really...)
