### PR TITLE
centos-release-gluster package added.

### DIFF
--- a/cookbooks/mu-glusterfs/recipes/server.rb
+++ b/cookbooks/mu-glusterfs/recipes/server.rb
@@ -15,7 +15,7 @@ case node[:platform]
     include_recipe "mu-glusterfs"
     $nodeclass = node.gluster_node_class
 
-    %w{xfsprogs mdadm glusterfs-server samba-vfs-glusterfs samba-client}.each do |pkg|
+    %w{xfsprogs mdadm centos-release-gluster glusterfs-server samba-vfs-glusterfs samba-client}.each do |pkg|
       package pkg
     end
 


### PR DESCRIPTION
This package is needed to install glusterfs from CentOs Extras repo.