### PR TITLE
Repo unnecessary

### DIFF
--- a/cookbooks/mu-glusterfs/recipes/default.rb
+++ b/cookbooks/mu-glusterfs/recipes/default.rb
@@ -10,12 +10,12 @@
 case node[:platform]
   when "centos"
 
-    yum_repository "glusterfs" do
-      description 'Glusterfs latest release repo'
-      url "http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/epel-$releasever/$basearch/"
-      enabled true
-      gpgkey "http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/rsa.pub"
-    end
+    # yum_repository "glusterfs" do
+    #   description 'Glusterfs latest release repo'
+    #   url "http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/epel-$releasever/$basearch/"
+    #   enabled true
+    #   gpgkey "http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/rsa.pub"
+    # end
 
     yum_repository "glusterfs-samba" do
       description 'Glusterfs Samba repo'


### PR DESCRIPTION
glusterfs packages are available via the CentOs Extras repo. This repository configuration is no longer needed.