### PR TITLE
more aggressive handling of Windows reboot irregularities

### DIFF
--- a/cookbooks/mu-activedirectory/providers/domain.rb
+++ b/cookbooks/mu-activedirectory/providers/domain.rb
@@ -99,7 +99,10 @@ def create_domain
     cmd = powershell_out(code)
     kill_ssh
     Chef::Application.fatal!("Failed to create Active Directory Domain #{new_resource.dns_name}") if cmd.exitstatus != 0
-    Chef::Application.fatal!("Active Directory Domain #{new_resource.dns_name} was created, rebooting. Will have to run chef again")
+    reboot "Active Directory Domain #{new_resource.dns_name} created" do
+      action :reboot_now
+      reason "Active Directory Domain #{new_resource.dns_name} created"
+    end
   end
 end
 

--- a/cookbooks/mu-tools/resources/sshd_service.rb
+++ b/cookbooks/mu-tools/resources/sshd_service.rb
@@ -21,9 +21,18 @@ action :config do
     unless ssh_user_set
       # cmd = powershell_out("c:/bin/cygwin/bin/bash --login -c 'chown -R #{new_resource.username} /var/empty && chown #{new_resource.username} /var/log/sshd.log /etc/ssh*\'; Stop-Process -ProcessName #{new_resource.name} -force; Stop-Service #{new_resource.name} -Force; Start-Service #{new_resource.name}; sleep 5; Start-Service #{new_resource.name}")
       # We would much prefer to use the above because that wouldn't  require another reboot, but in some cases the session dosen't get terminated from  Mu. Throwing Chef::Application.fatal seems to work more reliably
-      cmd = powershell_out("c:/bin/cygwin/bin/bash --login -c 'chown -R #{new_resource.username} /var/empty && chown #{new_resource.username} /var/log/sshd.log /etc/ssh*\'; Restart-Computer -force")
+      cmd = powershell_out("c:/bin/cygwin/bin/bash --login -c 'chown -R #{new_resource.username} /var/empty && chown #{new_resource.username} /var/log/sshd.log /etc/ssh*\'")
+      execute "kill ssh for reboot" do
+        command "Taskkill /im sshd.exe /f /t"
+        returns [0, 128, 1115]
+        action :nothing
+      end
+      reboot "Setting Cygwin ssh user to #{new_resource.username}" do
+        action :reboot_now
+        reason "Setting Cygwin ssh user to #{new_resource.username}"
+        notifies :run, "execute[kill ssh for reboot]", :immediately
+      end
       kill_ssh
-      Chef::Application.fatal!("Cygwin sux")
     end
   end
 end

--- a/modules/mu/clouds/aws/server.rb
+++ b/modules/mu/clouds/aws/server.rb
@@ -559,12 +559,49 @@ module MU
         end
 
         # Ask the Amazon API to restart this node
-        def reboot
+        def reboot(hard = false)
           return if @cloud_id.nil?
-          MU.log "Rebooting #{@mu_name} (#{@cloud_id})"
-          MU::Cloud::AWS.ec2(@config['region']).reboot_instances(
-            instance_ids: [@cloud_id]
-          )
+
+          if hard
+            groupname = nil
+            if !@config['basis'].nil?
+              resp = MU::Cloud::AWS.autoscale(@config['region']).describe_auto_scaling_instances(
+                instance_ids: [@cloud_id]
+              )
+              groupname = resp.auto_scaling_instances.first.auto_scaling_group_name
+              MU.log "Pausing Autoscale processes in #{groupname}", MU::NOTICE
+              MU::Cloud::AWS.autoscale(@config['region']).suspend_processes(
+                auto_scaling_group_name: groupname
+              )
+            end
+            begin
+              MU.log "Stopping #{@mu_name} (#{@cloud_id})", MU::NOTICE
+              MU::Cloud::AWS.ec2(@config['region']).stop_instances(
+                instance_ids: [@cloud_id]
+              )
+              MU::Cloud::AWS.ec2(@config['region']).wait_until(:instance_stopped, instance_ids: [@cloud_id]) do |waiter|
+                waiter.before_attempt do |attempts|
+                  MU.log "Waiting for #{@mu_name} to stop for hard reboot"
+                end
+              end
+              MU.log "Starting #{@mu_name} (#{@cloud_id})"
+              MU::Cloud::AWS.ec2(@config['region']).start_instances(
+                instance_ids: [@cloud_id]
+              )
+            ensure
+              if !groupname.nil?
+                MU.log "Resuming Autoscale processes in #{groupname}", MU::NOTICE
+                MU::Cloud::AWS.autoscale(@config['region']).resume_processes(
+                  auto_scaling_group_name: groupname
+                )
+              end
+            end
+          else
+            MU.log "Rebooting #{@mu_name} (#{@cloud_id})"
+            MU::Cloud::AWS.ec2(@config['region']).reboot_instances(
+              instance_ids: [@cloud_id]
+            )
+          end
         end
 
         # Figure out what's needed to SSH into this server.


### PR DESCRIPTION
Two changes here, which in theory should only impact Windows. We've been getting more weird failures bootstrapping Windows nodes, most of which seem to involve getting stuck and failing to reboot.

- Places in Chef where we trigger a reboot for Windows nodes are now using the Chef `reboot` resource. This is also set to trigger the `kill_ssh` helper or its equivalent, though that doesn't seem to help. I've removed certain things that try to trigger reboots themselves right before these calls, as that seems to confuse matters.

- When it inevitably gets stuck anyway, `MU::Cloud` still tries to force a Reboot from the API. Even that often fails now, so it has a second pass where it does a Stop, waits for it, and then Starts it again. If it's a node in an Autoscale group, it suspends scaling processes while that's happening.

@amirahav, if this muddles anything you're working on with 2016 or w/e, your feedback is encouraged.