### PR TITLE
Machine type translator

### DIFF
--- a/bin/mu-aws-setup
+++ b/bin/mu-aws-setup
@@ -46,8 +46,6 @@ Usage:
   opt :ephemeral, "Make sure all of our instance store (ephemeral) block devices are mapped and available.", :require => false, :default => false, :type => :boolean
 end
 
-##MU::Cloud::AWS.listInstanceTypes("us-gov-west-1")
-pp MU::Cloud::Google.listInstanceTypes
 
 my_instance_id = MU::Cloud::AWS.getAWSMetaData("instance-id")
 
@@ -57,8 +55,9 @@ instance = resp.reservations.first.instances.first
 preferred_ip = MU.mu_public_ip
 
 if $opts[:ephemeral]
-  if instance.instance_type.match(/^(t2|m4)\./)
-    MU.log "t2 and m4 instance types do not have ephemeral volumes, skipping setup", MU::WARN
+  instancetypes = MU::Cloud::AWS.listInstanceTypes
+  if instancetypes[MU.myRegion][instance.instance_type]["storage"] == "EBS only"
+    MU.log "#{instance.instance_type} instance types do not have ephemeral volumes, skipping ephemeral device setup", MU::NOTICE
   else
 #    instance.block_device_mappings.each { |dev|
 #      next if dev.ebs

--- a/bin/mu-aws-setup
+++ b/bin/mu-aws-setup
@@ -46,6 +46,9 @@ Usage:
   opt :ephemeral, "Make sure all of our instance store (ephemeral) block devices are mapped and available.", :require => false, :default => false, :type => :boolean
 end
 
+##MU::Cloud::AWS.listInstanceTypes("us-gov-west-1")
+pp MU::Cloud::Google.listInstanceTypes
+
 my_instance_id = MU::Cloud::AWS.getAWSMetaData("instance-id")
 
 resp = MU::Cloud::AWS.ec2.describe_instances(instance_ids: [my_instance_id])

--- a/cookbooks/mu-master/recipes/init.rb
+++ b/cookbooks/mu-master/recipes/init.rb
@@ -31,7 +31,7 @@ require 'socket'
 CHEF_SERVER_VERSION="12.17.15-1"
 CHEF_CLIENT_VERSION="12.21.31-1"
 KNIFE_WINDOWS="1.9.0"
-MU_BRANCH="the_goog"
+MU_BRANCH="machine_type_translator"
 MU_BASE="/opt/mu"
 
 begin

--- a/install/installer
+++ b/install/installer
@@ -4,8 +4,8 @@ BOLD=`tput bold`
 NORM=`tput sgr0`
 CHEF_CLIENT_VERSION="12.21.31-1"
 if [ "$MU_BRANCH" == "" ];then
-  MU_BRANCH="the_goog"
-  MU_BRANCH="the_goog"
+  MU_BRANCH="machine_type_translator"
+  MU_BRANCH="machine_type_translator"
 fi
 
 # XXX All RHEL family. We can at least cover Debian-flavored hosts too, I bet.

--- a/modules/mu/cloud.rb
+++ b/modules/mu/cloud.rb
@@ -156,7 +156,7 @@ module MU
         :interface => self.const_get("Server"),
         :deps_wait_on_my_creation => false,
         :waits_on_parent_completion => false,
-        :class => generic_class_methods,
+        :class => generic_class_methods + [:validateInstanceType],
         :instance => generic_instance_methods + [:groom, :postBoot, :getSSHConfig, :canonicalIP, :getWindowsAdminPassword, :active?, :groomer, :mu_windows_name, :mu_windows_name=, :reboot, :addVolume]
       },
       :ServerPool => {

--- a/modules/mu/clouds/aws/server.rb
+++ b/modules/mu/clouds/aws/server.rb
@@ -2233,6 +2233,41 @@ module MU
           [toplevel_required, schema]
         end
 
+        # Confirm that the given instance size is valid for the given region.
+        # If someone accidentally specified an equivalent size from some other cloud provider, return something that makes sense. If nothing makes sense, return nil.
+        # @param size [String]: Instance type to check
+        # @param region [String]: Region to check against
+        # @return [String,nil]
+        def self.validateInstanceType(size, region)
+          types = (MU::Cloud::AWS.listInstanceTypes(region))[region]
+          if size.nil? or !types.has_key?(size)
+            # See if it's a type we can approximate from one of the other clouds
+            gtypes = (MU::Cloud::Google.listInstanceTypes)[MU::Cloud::Google.myRegion]
+            foundmatch = false
+            if gtypes and gtypes.size > 0 and gtypes.has_key?(size)
+              vcpu = gtypes[size]["vcpu"]
+              mem = gtypes[size]["memory"]
+              ecu = gtypes[size]["ecu"]
+              types.keys.sort.reverse.each { |type|
+                features = types[type]
+                next if ecu == "Variable" and ecu != features["ecu"]
+                next if features["vcpu"] != vcpu
+                if (features["memory"] - mem.to_f).abs < 0.10*mem
+                  foundmatch = true
+                  MU.log "You specified a Google Compute instance type '#{size}.' Approximating with Amazon EC2 type '#{type}.'", MU::WARN
+                  size = type
+                  break
+                end
+              }
+            end
+            if !foundmatch
+              MU.log "Invalid size '#{size}' for AWS EC2 instance in #{region}. Supported types:", MU::ERR, details: types.keys.sort.join(", ")
+              return nil
+            end
+          end
+          size
+        end
+
         # Cloud-specific pre-processing of {MU::Config::BasketofKittens::servers}, bare and unvalidated.
         # @param server [Hash]: The resource to process and validate
         # @param configurator [MU::Config]: The overall deployment configurator of which this resource is a member
@@ -2240,34 +2275,8 @@ module MU
         def self.validateConfig(server, configurator)
           ok = true
 
-          region = server["region"]
-
-          types = (MU::Cloud::AWS.listInstanceTypes(region))[region]
-          if server["size"].nil? or !types.has_key?(server["size"])
-            # See if it's a type we can approximate from one of the other clouds
-            gtypes = (MU::Cloud::Google.listInstanceTypes)[MU::Cloud::Google.myRegion]
-            foundmatch = false
-            if gtypes and gtypes.size > 0 and gtypes.has_key?(server["size"])
-              vcpu = gtypes[server["size"]]["vcpu"]
-              mem = gtypes[server["size"]]["memory"]
-              ecu = gtypes[server["size"]]["ecu"]
-              types.keys.sort.reverse.each { |type|
-                features = types[type]
-                next if ecu == "Variable" and ecu != features["ecu"]
-                next if features["vcpu"] != vcpu
-                if (features["memory"] - mem.to_f).abs < 0.10*mem
-                  foundmatch = true
-                  MU.log "You specified a Google Compute instance type '#{server["size"]}.' Approximating with Amazon EC2 type '#{type}.'", MU::WARN
-                  server["size"] = type
-                  break
-                end
-              }
-            end
-            if !foundmatch
-              MU.log "Invalid size '#{server['size']}' for AWS EC2 instance in #{region}. Supported types:", MU::ERR, details: types.keys.sort.join(", ")
-              ok = false
-            end
-          end
+          server['size'] = validateInstanceType(server["size"], server["region"])
+          ok = false if server['size'].nil?
 
           if !server['generate_iam_role']
             if !server['iam_role'] and server['cloud'] != "CloudFormation"

--- a/modules/mu/clouds/aws/server_pool.rb
+++ b/modules/mu/clouds/aws/server_pool.rb
@@ -596,6 +596,8 @@ module MU
         # @return [Boolean]: True if validation succeeded, False otherwise
         def self.validateConfig(pool, configurator)
           ok = true
+
+
           if !pool["schedule"].nil?
             pool["schedule"].each { |s|
               if !s['min_size'] and !s['max_size'] and !s['desired_capacity']
@@ -624,6 +626,9 @@ module MU
 
           if !pool["basis"]["launch_config"].nil?
             launch = pool["basis"]["launch_config"]
+
+            launch['size'] = MU::Cloud::AWS::Server.validateInstanceType(launch["size"], pool["region"])
+            ok = false if launch['size'].nil?
             if !launch['generate_iam_role']
               if !launch['iam_role'] and pool['cloud'] != "CloudFormation"
                 MU.log "Must set iam_role if generate_iam_role set to false", MU::ERR

--- a/modules/mu/clouds/cloudformation/server.rb
+++ b/modules/mu/clouds/cloudformation/server.rb
@@ -347,6 +347,15 @@ module MU
           MU::Cloud::AWS::Server.schema(config)
         end
 
+        # Confirm that the given instance size is valid for the given region.
+        # If someone accidentally specified an equivalent size from some other cloud provider, return something that makes sense. If nothing makes sense, return nil.
+        # @param size [String]: Instance type to check
+        # @param region [String]: Region to check against
+        # @return [String,nil]
+        def self.validateInstanceType(size, region)
+          MU::Cloud::AWS::Server.validateInstanceType(size, region)
+        end
+
         # Cloud-specific pre-processing of {MU::Config::BasketofKittens::servers}, bare and unvalidated.
         # @param server [Hash]: The resource to process and validate
         # @param configurator [MU::Config]: The overall deployment configurator of which this resource is a member

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -296,6 +296,32 @@ module MU
         end
       end
 
+
+      @@instance_types = nil
+      # Query the GCP API for the list of valid EC2 instance types and some of
+      # their attributes. We can use this in config validation and to help
+      # "translate" machine types across cloud providers.
+      # @param region [String]: Supported machine types can vary from region to region, so we look for the set we're interested in specifically
+      # @return [Hash]
+      def self.listInstanceTypes(region = myRegion)
+        return @@instance_types if @@instance_types and @@instance_types[region]
+
+        @@instance_types ||= {}
+        @@instance_types[region] ||= {}
+        result = MU::Cloud::Google.compute.list_machine_types(MU::Cloud::Google.defaultProject, listAZs(region).first)
+        result.items.each { |type|
+          @@instance_types[region][type.name] ||= {}
+          @@instance_types[region][type.name]["memory"] = sprintf("%.1f", type.memory_mb/1024.0)
+          @@instance_types[region][type.name]["vcpu"] = type.guest_cpus
+          if type.is_shared_cpu
+            @@instance_types[region][type.name]["ecu"] = "Variable"
+          else
+            @@instance_types[region][type.name]["ecu"] = type.guest_cpus
+          end
+        }
+        @@instance_types
+      end
+
       # Google has fairly strict naming conventions (all lowercase, no
       # underscores, etc). Provide a wrapper to our standard names to handle it.
       def self.nameStr(name)

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -544,22 +544,17 @@ module MU
               end
               if retries <= 1 and e.message.match(/^accessNotConfigured/)
                 enable_obj = nil
-                if arguments.first # aka if there's a project id
-                  enable_obj = MU::Cloud::Google.service_manager(:EnableServiceRequest).new(
-                    consumer_id: "project:"+arguments.first.to_s
-                  )
-                end
+                project = arguments.size > 0 ? arguments.first.to_s : MU::Cloud::Google.defaultProject
+                enable_obj = MU::Cloud::Google.service_manager(:EnableServiceRequest).new(
+                  consumer_id: "project:"+project
+                )
                 # XXX dumbass way to get this string
                 e.message.match(/Enable it by visiting https:\/\/console\.developers\.google\.com\/apis\/api\/(.+?)\//)
                 svc_name = Regexp.last_match[1]
                 save_verbosity = MU.verbosity
                 if svc_name != "servicemanagement.googleapis.com"
                   MU.setLogging(MU::Logger::NORMAL)
-                  if arguments.first
-                    MU.log "Attempting to enable #{svc_name} in project #{arguments.first}, then waiting for 30s", MU::WARN
-                  else
-                    MU.log "Attempting to enable #{svc_name}, then waiting for 30s", MU::WARN
-                  end
+                  MU.log "Attempting to enable #{svc_name} in project #{project}, then waiting for 30s", MU::WARN
                   MU.setLogging(save_verbosity)
                   MU::Cloud::Google.service_manager.enable_service(svc_name, enable_obj)
                   sleep 30

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -394,7 +394,7 @@ module MU
         end
       end
 
-      # Google's Service Manager API (the one you use to enable other APIs)
+      # Google's Service Manager API (the one you use to enable pre-project APIs)
       # @param subclass [<Google::Apis::ServicemanagementV1>]: If specified, will return the class ::Google::Apis::ServicemanagementV1::subclass instead of an API client instance
       def self.service_manager(subclass = nil)
         require 'google/apis/servicemanagement_v1'
@@ -542,18 +542,35 @@ module MU
               if e.message.match(/^invalidParameter:/)
                 MU.log "#{method_sym.to_s}: "+e.message, MU::ERR, details: arguments
               end
-              if retries <= 1 and e.message.match(/^accessNotConfigured/) and arguments.first
-                enable_obj = MU::Cloud::Google.service_manager(:EnableServiceRequest).new(
-                  consumer_id: "project:"+arguments.first.to_s, # there's always a project id
-                )
+              if retries <= 1 and e.message.match(/^accessNotConfigured/)
+                enable_obj = nil
+                if arguments.first # aka if there's a project id
+                  enable_obj = MU::Cloud::Google.service_manager(:EnableServiceRequest).new(
+                    consumer_id: "project:"+arguments.first.to_s
+                  )
+                end
                 # XXX dumbass way to get this string
                 e.message.match(/Enable it by visiting https:\/\/console\.developers\.google\.com\/apis\/api\/(.+?)\//)
                 svc_name = Regexp.last_match[1]
-                MU.log "Attempting to enable #{svc_name} in project #{arguments.first}, then waiting for 30s", MU::WARN
-                MU::Cloud::Google.service_manager.enable_service(svc_name, enable_obj)
-                sleep 30
-                retries += 1
-                retry
+                save_verbosity = MU.verbosity
+                if svc_name != "servicemanagement.googleapis.com"
+                  MU.setLogging(MU::Logger::NORMAL)
+                  if arguments.first
+                    MU.log "Attempting to enable #{svc_name} in project #{arguments.first}, then waiting for 30s", MU::WARN
+                  else
+                    MU.log "Attempting to enable #{svc_name}, then waiting for 30s", MU::WARN
+                  end
+                  MU.setLogging(save_verbosity)
+                  MU::Cloud::Google.service_manager.enable_service(svc_name, enable_obj)
+                  sleep 30
+                  retries += 1
+                  retry
+                else
+                  MU.setLogging(MU::Logger::NORMAL)
+                  MU.log "Google Cloud's Service Management API must be enabled manually by visiting #{e.message.gsub(/.*?(https?:\/\/[^\s]+)(?:$|\s).*/, '\1')}", MU::ERR
+                  MU.setLogging(save_verbosity)
+                  raise MU::MuError, "Service Management API not yet enabled for this account/project"
+                end
               elsif retries <= 10 and
                  e.message.match(/^resourceNotReady:/) or
                  (e.message.match(/^resourceInUseByAnotherResource:/) and method_sym.to_s.match(/^delete_/))

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -305,14 +305,17 @@ module MU
       # @return [Hash]
       def self.listInstanceTypes(region = myRegion)
         return @@instance_types if @@instance_types and @@instance_types[region]
+        if !MU::Cloud::Google.defaultProject
+          return {}
+        end
 
         @@instance_types ||= {}
         @@instance_types[region] ||= {}
         result = MU::Cloud::Google.compute.list_machine_types(MU::Cloud::Google.defaultProject, listAZs(region).first)
         result.items.each { |type|
           @@instance_types[region][type.name] ||= {}
-          @@instance_types[region][type.name]["memory"] = sprintf("%.1f", type.memory_mb/1024.0)
-          @@instance_types[region][type.name]["vcpu"] = type.guest_cpus
+          @@instance_types[region][type.name]["memory"] = sprintf("%.1f", type.memory_mb/1024.0).to_f
+          @@instance_types[region][type.name]["vcpu"] = type.guest_cpus.to_f
           if type.is_shared_cpu
             @@instance_types[region][type.name]["ecu"] = "Variable"
           else


### PR DESCRIPTION
Config parser validation of instance types ('size' parameter) on `Servers` and `ServerPools` now asks the relevant cloud provider APIs what's legit for a given region.

GCP instance types accidentally specified in an AWS stack, and vice versa, will attempt to translate to an equivalent machine type if one exists.