### PR TITLE
Add Option to mu-node-manage To Disable SSH Fallback for WinRM Connections

### DIFF
--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -255,13 +255,12 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             if (!resp or resp.exitcode != 0)
               if $opts[:winrm]
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
-                output = resp.stdout
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
-                puts resp.stderr if resp and resp.stderr
-                puts resp.stdout if resp and resp.stdout
-                output = nil
               end
+              puts resp.stderr if resp and resp.stderr
+              puts resp.stdout if resp and resp.stdout
+              output = nil
             else
               exec_shell = 'WinRM'
               output = resp.stdout

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -327,14 +327,14 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             exit exitcode if done
 
           else
-            MU.log "#{nodename} complete via #{exec_shell}"
+            MU.log "#{nodename} complete via #{exec_protocol}"
             done = true
           end
 
         end until done
 
         puts "#{nodename} - #{output}" if print_output and output.match(/[^\s]/)
-        
+
       }
       $children[child] = nodename
       while $children.size >= $opts[:concurrent] - 1

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -243,8 +243,10 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
           MU.log "Running '#{cmd}' on #{nodename} (##{count})" if !print_output
           output = nil
           exitcode = -1
+          exec_shell = 'ssh'
           if serverobj.windows?
             resp = nil
+            exec_shell = 'WinRM'
             begin
               shell = serverobj.getWinRMSession(0, timeout: 10, winrm_retries: 1)
               resp = shell.run(cmd)
@@ -255,13 +257,10 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
                 MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
               else
                 MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
-                # if chefrun and serverobj.windows?
-                #   cmd = "chef-client.bat --no-fips"
-                #   cmd += " -o '#{chef_runlist}'" if chef_runlist
-                # end
               end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
+              exec_shell = 'ssh'
               output = nil
             else
 
@@ -295,7 +294,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
             exit exitcode if done
           else
-            MU.log "#{nodename} complete"
+            MU.log "#{nodename} complete via #{exec_shell}"
             done = true
           end
         end until done

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -237,16 +237,16 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
         begin
           serverobj = mommacat.findLitterMate(type: "server", mu_name: nodename)
           if chefrun
-            cmd = serverobj.windows? ? "chef-client --no-fips" : "chef-client || sudo chef-client"
+            cmd = serverobj.windows? ? "powershell -Command chef-client" : "chef-client || sudo chef-client"
             cmd += " -o '#{chef_runlist}'" if chef_runlist
           end
           MU.log "Running '#{cmd}' on #{nodename} (##{count})" if !print_output
           output = nil
           exitcode = -1
-          exec_shell = 'ssh'
+          exec_shell = 'SSH'
           if serverobj.windows?
             resp = nil
-            exec_shell = 'WinRM'
+            
             begin
               shell = serverobj.getWinRMSession(0, timeout: 10, winrm_retries: 1)
               resp = shell.run(cmd)
@@ -258,12 +258,11 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               else
                 MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
               end
-              puts resp.stderr if resp and resp.stderr
-              puts resp.stdout if resp and resp.stdout
-              exec_shell = 'ssh'
+              # puts resp.stderr if resp and resp.stderr
+              # puts resp.stdout if resp and resp.stdout
               output = nil
             else
-
+              exec_shell = 'WinRM'
               output = resp.stdout
               exitcode = resp.exitcode
             end

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -294,7 +294,11 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
             exit exitcode if done
           else
-            MU.log "#{nodename} complete via #{exec_shell}"
+            if serverobj.windows?
+              MU.log "#{nodename} complete via #{exec_shell}"
+            else
+              MU.log "#{nodename} complete"
+            end
             done = true
           end
         end until done

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -33,7 +33,7 @@ Usage:
   opt :xecute, "Run a shell command on matching nodes. Overrides --mode and suppresses some informational output in favor of scriptability.", :require => false, :type => :string
   opt :mode, "Action to perform on matching nodes. Valid actions: groom, chefrun, awsmeta, vaults, certs, chefupgrade", :require => false, :default => "chefrun", :type => :string
   opt :verbose, "Show output from Chef runs, etc", :require => false, :default => false, :type => :boolean
-  opt :winrm, "Force WinRM connection. Default causes mu to attempt to fallback to SSH", :require => false, :default => false, :type => :boolean
+  opt :winrm, "Force WinRM connection. Disable SSH fallback", :require => false, :default => false, :type => :boolean
   opt :info, "List a particular node attribute", :require => false, :default => 'nodename', :type => :string
 end
 

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -250,7 +250,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               resp = shell.run(cmd)
             rescue MU::MuError => e
             end
-            if (!resp or resp.exitcode != 0) and !($opts[:mode])
+            if (!resp or resp.exitcode != 0) and !($opts[:winrm])
               MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::WARN
               if chefrun and serverobj.windows?
                 cmd = "chef-client.bat --no-fips"
@@ -260,7 +260,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               puts resp.stdout if resp and resp.stdout
               output = nil
             else
-              if !($opts[:mode])
+              if $opts[:winrm]
                 MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
               end
               output = resp.stdout

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -33,7 +33,7 @@ Usage:
   opt :xecute, "Run a shell command on matching nodes. Overrides --mode and suppresses some informational output in favor of scriptability.", :require => false, :type => :string
   opt :mode, "Action to perform on matching nodes. Valid actions: groom, chefrun, awsmeta, vaults, certs, chefupgrade", :require => false, :default => "chefrun", :type => :string
   opt :verbose, "Show output from Chef runs, etc", :require => false, :default => false, :type => :boolean
-  opt :winrm, "Force WinRM connection", :require => false, :default => false, :type => :boolean
+  opt :winrm, "Force WinRM connection. Default causes mu to attempt to fallback to SSH", :require => false, :default => false, :type => :boolean
   opt :info, "List a particular node attribute", :require => false, :default => 'nodename', :type => :string
 end
 
@@ -260,6 +260,9 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               puts resp.stdout if resp and resp.stdout
               output = nil
             else
+              if !($opts[:mode])
+                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
+              end
               output = resp.stdout
               exitcode = resp.exitcode
             end

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -257,10 +257,11 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
+                output = nil
               end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
-              output = nil
+              
             else
               exec_shell = 'WinRM'
               output = resp.stdout

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -236,76 +236,105 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
         done = false
         begin
           serverobj = mommacat.findLitterMate(type: "server", mu_name: nodename)
+
+          # Generate the command if attemting a chef run
           if chefrun
             cmd = serverobj.windows? ? "powershell -Command chef-client" : "chef-client || sudo chef-client"
             cmd += " -o '#{chef_runlist}'" if chef_runlist
           end
+
           MU.log "Running '#{cmd}' on #{nodename} (##{count})" if !print_output
+
+          # Set Variables to catch the output and exit code of the execution
           output = nil
           exitcode = -1
-          attempt_ssh = 1
+
+          # Determine which protocols to attempt
           if serverobj.windows?
-            resp = nil
-            attempt_ssh = 0
-            exec_shell = 'WinRM'
+            attempt_winrm = true
+            if $opts[:winrm]
+              attempt_ssh = false
+            else
+              attempt_ssh = true
+            end
+          else
+            attempt_winrm = false
+            attempt_ssh = true
+          end
+
+          # Attempt WinRM Connection, and Fall back to SSH
+          if attempt_winrm
+            exec_protocol = 'WinRM'
             
+            # Attempt to make a connection and exec the command
+            resp = nil
             begin
               shell = serverobj.getWinRMSession(0, timeout: 10, winrm_retries: 1)
               resp = shell.run(cmd)
             rescue MU::MuError => e
             end
 
-            output = resp.stdout if resp and resp.stdout
-            exitcode = resp.exitcode if resp and resp.exitcode
+            if resp
+              # WINRM CONNECTION AND EXECUTION SUCCESS
+              output = resp.stdout if resp.stdout
+              exitcode = resp.exitcode if resp.exitcode
 
-            # If the connection failed
-            if (!resp or exitcode != 0)
-              if $opts[:winrm]
-                MU.log "#{nodename} , NOT trying SSH", MU::WARN
+              if exitcode.eql? 0
+                attempt_ssh = false
               else
-                MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
-                attempt_ssh = 1
-                output = nil
-                exitcode = nil
+                puts resp.stderr if resp.stderr
+                puts output
               end
-              puts resp.stderr if resp and resp.stderr
-              puts resp.stdout if resp and resp.stdout
             end
 
+            if exitcode != 0
+              if attempt_ssh
+                MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
+              else
+                MU.log "#{nodename} WinRM exec failed, NOT trying SSH", MU::WARN
+              end
+            end
           end
 
           if attempt_ssh
-            exec_shell = 'SSH'
+            exec_protocol = 'SSH'
+
             # this should use getSSHSession, for the sake of symmetry
             output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
             exitcode = $?.exitstatus
-            # XXX Some Windows nodes need --no-fips right now. And some don't
-            # know what that is. Try to accommodate both.
-            if chefrun and serverobj.windows? and exitcode != 0
-              cmd = "powershell -Command chef-client --no-fips"
-              cmd += " -o '#{chef_runlist}'" if chef_runlist
-              output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
-              exitcode = $?.exitstatus
-            end
           end
+
           if exitcode != 0
-            if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)
-              MU.log "#{nodename} encountered transient Windows/Chef ConnectServer error, retrying", MU::WARN
-            elsif print_output
-              done = true
-              puts "#{nodename} - #{output}" if output.match(/[^\s]/)
-              MU.log "#{nodename} did not exit cleanly", MU::WARN
+
+            if output
+
+              if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)
+                MU.log "#{nodename} encountered transient Windows/Chef ConnectServer error, retrying", MU::WARN
+              elsif print_output
+                done = true
+                puts "#{nodename} - #{output}" if output.match(/[^\s]/)
+                MU.log "#{nodename} did not exit cleanly", MU::WARN
+              else
+                done = true
+                MU.log "#{nodename} did not exit cleanly", MU::WARN, details: output.slice(-2000, 2000)
+              end
+
             else
               done = true
-              MU.log "#{nodename} did not exit cleanly", MU::WARN, details: output.slice(-2000, 2000)
+              MU.log "#{nodename} did not exit cleanly", MU::WARN
             end
+
             exit exitcode if done
+
           else
             MU.log "#{nodename} complete via #{exec_shell}"
             done = true
           end
+
         end until done
+
         puts "#{nodename} - #{output}" if print_output and output.match(/[^\s]/)
+        
       }
       $children[child] = nodename
       while $children.size >= $opts[:concurrent] - 1

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -273,12 +273,12 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             exitcode = $?.exitstatus
             # XXX Some Windows nodes need --no-fips right now. And some don't
             # know what that is. Try to accommodate both.
-            # if chefrun and serverobj.windows? and exitcode != 0
-            #   cmd = "powershell -Command chef-client --no-fips"
-            #   cmd += " -o '#{chef_runlist}'" if chef_runlist
-            #   output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
-            #   exitcode = $?.exitstatus
-            # end
+            if chefrun and serverobj.windows? and exitcode != 0
+              cmd = "powershell -Command chef-client --no-fips"
+              cmd += " -o '#{chef_runlist}'" if chef_runlist
+              output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
+              exitcode = $?.exitstatus
+            end
           end
           if exitcode != 0
             if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -257,10 +257,10 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
+                puts resp.stderr if resp and resp.stderr
+                puts resp.stdout if resp and resp.stdout
+                output = nil
               end
-              puts resp.stderr if resp and resp.stderr
-              puts resp.stdout if resp and resp.stdout
-              output = nil
             else
               exec_shell = 'WinRM'
               output = resp.stdout
@@ -268,7 +268,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
           end
           if !output
-            if !$opts[:winrm]
+            if !serverobj.windows? or !$opts[:winrm]
               # this should use getSSHSession, for the sake of symmetry
               output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
               exitcode = $?.exitstatus

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -254,12 +254,12 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
             if (!resp or resp.exitcode != 0)
               if $opts[:winrm]
-                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
+                MU.log "#{nodename} , NOT trying SSH", MU::WARN
               else
-                MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
+                MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
               end
-              # puts resp.stderr if resp and resp.stderr
-              # puts resp.stdout if resp and resp.stdout
+              puts resp.stderr if resp and resp.stderr
+              puts resp.stdout if resp and resp.stdout
               output = nil
             else
               exec_shell = 'WinRM'
@@ -273,12 +273,12 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             exitcode = $?.exitstatus
             # XXX Some Windows nodes need --no-fips right now. And some don't
             # know what that is. Try to accommodate both.
-            if chefrun and serverobj.windows? and exitcode != 0
-              cmd = "powershell -Command chef-client"
-              cmd += " -o '#{chef_runlist}'" if chef_runlist
-              output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
-              exitcode = $?.exitstatus
-            end
+            # if chefrun and serverobj.windows? and exitcode != 0
+            #   cmd = "powershell -Command chef-client --no-fips"
+            #   cmd += " -o '#{chef_runlist}'" if chef_runlist
+            #   output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
+            #   exitcode = $?.exitstatus
+            # end
           end
           if exitcode != 0
             if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)
@@ -293,11 +293,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
             exit exitcode if done
           else
-            if serverobj.windows?
-              MU.log "#{nodename} complete via #{exec_shell}"
-            else
-              MU.log "#{nodename} complete"
-            end
+            MU.log "#{nodename} complete via #{exec_shell}"
             done = true
           end
         end until done

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -267,17 +267,19 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               exitcode = resp.exitcode
             end
           end
-          if !output and !$opts[:winrm]
-            # this should use getSSHSession, for the sake of symmetry
-            output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
-            exitcode = $?.exitstatus
-            # XXX Some Windows nodes need --no-fips right now. And some don't
-            # know what that is. Try to accommodate both.
-            if chefrun and serverobj.windows? and exitcode != 0
-              cmd = "powershell -Command chef-client --no-fips"
-              cmd += " -o '#{chef_runlist}'" if chef_runlist
+          if !output
+            if !$opts[:winrm]
+              # this should use getSSHSession, for the sake of symmetry
               output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
               exitcode = $?.exitstatus
+              # XXX Some Windows nodes need --no-fips right now. And some don't
+              # know what that is. Try to accommodate both.
+              if chefrun and serverobj.windows? and exitcode != 0
+                cmd = "powershell -Command chef-client --no-fips"
+                cmd += " -o '#{chef_runlist}'" if chef_runlist
+                output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
+                exitcode = $?.exitstatus
+              end
             end
           end
           if exitcode != 0

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -251,15 +251,15 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             rescue MU::MuError => e
             end
             if (!resp or resp.exitcode != 0)
-              if $opts[:winrm]
-                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
-              else
-                MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::WARN
-                if chefrun and serverobj.windows?
-                  cmd = "chef-client.bat --no-fips"
-                  cmd += " -o '#{chef_runlist}'" if chef_runlist
-                end
-              end
+              # if $opts[:winrm]
+              #   MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
+              # else
+              #   MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
+              #   # if chefrun and serverobj.windows?
+              #   #   cmd = "chef-client.bat --no-fips"
+              #   #   cmd += " -o '#{chef_runlist}'" if chef_runlist
+              #   # end
+              # end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
               output = nil
@@ -269,18 +269,21 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               exitcode = resp.exitcode
             end
           end
-          if !output
-            # maybe this should use getSSHSession, for the sake of symmetry
+          if !output and !$opts[:winrm]
+            MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
+            # this should use getSSHSession, for the sake of symmetry
             output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
             exitcode = $?.exitstatus
             # XXX Some Windows nodes need --no-fips right now. And some don't
             # know what that is. Try to accommodate both.
             if chefrun and serverobj.windows? and exitcode != 0
-              cmd = "chef-client.bat"
+              cmd = "powershell -Command chef-client"
               cmd += " -o '#{chef_runlist}'" if chef_runlist
               output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
               exitcode = $?.exitstatus
             end
+          else
+            MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
           end
           if exitcode != 0
             if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -255,13 +255,14 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             if (!resp or resp.exitcode != 0)
               if $opts[:winrm]
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
+                output = resp.stdout
+                exitcode = resp.exitcode
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
                 output = nil
               end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
-              
             else
               exec_shell = 'WinRM'
               output = resp.stdout

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -250,19 +250,21 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               resp = shell.run(cmd)
             rescue MU::MuError => e
             end
-            if (!resp or resp.exitcode != 0) and !($opts[:winrm])
-              MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::WARN
-              if chefrun and serverobj.windows?
-                cmd = "chef-client.bat --no-fips"
-                cmd += " -o '#{chef_runlist}'" if chef_runlist
+            if (!resp or resp.exitcode != 0)
+              if $opts[:winrm]
+                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
+              else
+                MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::WARN
+                if chefrun and serverobj.windows?
+                  cmd = "chef-client.bat --no-fips"
+                  cmd += " -o '#{chef_runlist}'" if chef_runlist
+                end
               end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
               output = nil
             else
-              if $opts[:winrm]
-                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
-              end
+
               output = resp.stdout
               exitcode = resp.exitcode
             end

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -243,45 +243,49 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
           MU.log "Running '#{cmd}' on #{nodename} (##{count})" if !print_output
           output = nil
           exitcode = -1
-          exec_shell = 'SSH'
+          attempt_ssh = 1
           if serverobj.windows?
             resp = nil
+            attempt_ssh = 0
+            exec_shell = 'WinRM'
             
             begin
               shell = serverobj.getWinRMSession(0, timeout: 10, winrm_retries: 1)
               resp = shell.run(cmd)
             rescue MU::MuError => e
             end
-            if (!resp or resp.exitcode != 0)
+
+            output = resp.stdout if resp and resp.stdout
+            exitcode = resp.exitcode if resp and resp.exitcode
+
+            # If the connection failed
+            if (!resp or exitcode != 0)
               if $opts[:winrm]
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
-                output = resp.stdout
-                exitcode = resp.exitcode
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
+                attempt_ssh = 1
                 output = nil
+                exitcode = nil
               end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
-            else
-              exec_shell = 'WinRM'
-              output = resp.stdout
-              exitcode = resp.exitcode
             end
+
           end
-          if !output
-            if !serverobj.windows? or !$opts[:winrm]
-              # this should use getSSHSession, for the sake of symmetry
+
+          if attempt_ssh
+            exec_shell = 'SSH'
+            # this should use getSSHSession, for the sake of symmetry
+            output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
+            exitcode = $?.exitstatus
+            # XXX Some Windows nodes need --no-fips right now. And some don't
+            # know what that is. Try to accommodate both.
+            if chefrun and serverobj.windows? and exitcode != 0
+              cmd = "powershell -Command chef-client --no-fips"
+              cmd += " -o '#{chef_runlist}'" if chef_runlist
               output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
               exitcode = $?.exitstatus
-              # XXX Some Windows nodes need --no-fips right now. And some don't
-              # know what that is. Try to accommodate both.
-              if chefrun and serverobj.windows? and exitcode != 0
-                cmd = "powershell -Command chef-client --no-fips"
-                cmd += " -o '#{chef_runlist}'" if chef_runlist
-                output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
-                exitcode = $?.exitstatus
-              end
             end
           end
           if exitcode != 0

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -255,6 +255,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             if (!resp or resp.exitcode != 0)
               if $opts[:winrm]
                 MU.log "#{nodename} , NOT trying SSH", MU::WARN
+                output = resp.stdout
               else
                 MU.log "#{nodename} WinRM exec failed, trying SSH", MU::NOTICE
                 puts resp.stderr if resp and resp.stderr

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -251,15 +251,15 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             rescue MU::MuError => e
             end
             if (!resp or resp.exitcode != 0)
-              # if $opts[:winrm]
-              #   MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
-              # else
-              #   MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
-              #   # if chefrun and serverobj.windows?
-              #   #   cmd = "chef-client.bat --no-fips"
-              #   #   cmd += " -o '#{chef_runlist}'" if chef_runlist
-              #   # end
-              # end
+              if $opts[:winrm]
+                MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
+              else
+                MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
+                # if chefrun and serverobj.windows?
+                #   cmd = "chef-client.bat --no-fips"
+                #   cmd += " -o '#{chef_runlist}'" if chef_runlist
+                # end
+              end
               puts resp.stderr if resp and resp.stderr
               puts resp.stdout if resp and resp.stdout
               output = nil
@@ -270,7 +270,6 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
             end
           end
           if !output and !$opts[:winrm]
-            MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::NOTICE
             # this should use getSSHSession, for the sake of symmetry
             output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
             exitcode = $?.exitstatus
@@ -282,8 +281,6 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               output = `ssh -q #{nodename} "#{cmd}" 2>&1 < /dev/null`
               exitcode = $?.exitstatus
             end
-          else
-            MU.log "WinRM exec on #{nodename} failed, NOT trying SSH", MU::WARN
           end
           if exitcode != 0
             if serverobj.windows? and output.match(/NoMethodError: unknown property or method: `ConnectServer'/)

--- a/bin/mu-node-manage
+++ b/bin/mu-node-manage
@@ -33,6 +33,7 @@ Usage:
   opt :xecute, "Run a shell command on matching nodes. Overrides --mode and suppresses some informational output in favor of scriptability.", :require => false, :type => :string
   opt :mode, "Action to perform on matching nodes. Valid actions: groom, chefrun, awsmeta, vaults, certs, chefupgrade", :require => false, :default => "chefrun", :type => :string
   opt :verbose, "Show output from Chef runs, etc", :require => false, :default => false, :type => :boolean
+  opt :winrm, "Force WinRM connection", :require => false, :default => false, :type => :boolean
   opt :info, "List a particular node attribute", :require => false, :default => 'nodename', :type => :string
 end
 
@@ -249,7 +250,7 @@ def runCommand(deploys = MU::MommaCat.listDeploys, nodes = [], cmd = nil, print_
               resp = shell.run(cmd)
             rescue MU::MuError => e
             end
-            if !resp or resp.exitcode != 0
+            if (!resp or resp.exitcode != 0) and !($opts[:mode])
               MU.log "WinRM exec on #{nodename} failed, trying SSH", MU::WARN
               if chefrun and serverobj.windows?
                 cmd = "chef-client.bat --no-fips"


### PR DESCRIPTION
This is a small little feature, but it should help with debugging, and monitoring WinRM Connections. 

When this option is enabled it disables `mu-node-manage`'s automatic fallback. Allowing us to easily capture a WinRM failure, and wrap scripts to track it. 