### PR TITLE
more server attributes for EKS worker nodes

### DIFF
--- a/cookbooks/mu-tools/recipes/efs.rb
+++ b/cookbooks/mu-tools/recipes/efs.rb
@@ -48,7 +48,7 @@ if node['deployment'].has_key?('storage_pools')
           endpoint = target['ip_address']
         end
 
-        if node[:platform_family] == "rhel" and node[:platform_version].to_i < 6
+        if node[:platform_family] == "rhel" and node[:platform_version].to_i < 6 and node['platform'] != "amazon"
           service "portmap" do
             action [:enable, :start]
           end

--- a/cookbooks/mu-tools/recipes/eks.rb
+++ b/cookbooks/mu-tools/recipes/eks.rb
@@ -66,7 +66,7 @@ EOH
     package "kubelet"
     package "kubectl"
   else
-    Chef::Log.info("I don't know how to turn #{node['platform']} #{node[:platform_version].to_s} into a Kubernetes worker, hopefully it's pre-configured")
+    Chef::Log.info("I don't know how to turn this #{node['platform']} AMI (#{node[:platform_version].to_s}) into a Kubernetes worker, hopefully it's the official, pre-configured AMI")
   end
 
   service "docker" do

--- a/modules/mu/clouds/aws/container_cluster.rb
+++ b/modules/mu/clouds/aws/container_cluster.rb
@@ -622,6 +622,12 @@ module MU
               ]
               worker_pool["run_list"] = ["mu-tools::eks"]
 							worker_pool["run_list"].concat(cluster["run_list"]) if cluster["run_list"]
+              MU::Config::Server.common_properties.keys.each { |k|
+                if cluster[k] and !worker_pool[k]
+                  worker_pool[k] = cluster[k]
+                end
+              }
+
             end
 
             configurator.insertKitten(worker_pool, "server_pools")

--- a/modules/mu/clouds/aws/container_cluster.rb
+++ b/modules/mu/clouds/aws/container_cluster.rb
@@ -523,6 +523,13 @@ module MU
             "ami_id" => {
               "type" => "string",
               "description" => "The Amazon EC2 AMI on which to base this cluster's container hosts. Will use the default appropriate for the platform, if not specified."
+            },
+            "run_list" => {
+              "type" => "array",
+              "items" => {
+                  "type" => "string",
+                  "description" => "An extra Chef run list entry, e.g. role[rolename] or recipe[recipename]s, to be run on worker nodes."
+              }
             }
           }
           [toplevel_required, schema]
@@ -614,6 +621,7 @@ module MU
                 }
               ]
               worker_pool["run_list"] = ["mu-tools::eks"]
+							worker_pool["run_list"].concat(cluster["run_list"]) if cluster["run_list"]
             end
 
             configurator.insertKitten(worker_pool, "server_pools")

--- a/modules/mu/config/container_cluster.rb
+++ b/modules/mu/config/container_cluster.rb
@@ -20,7 +20,7 @@ module MU
       # Base configuration schema for a ContainerCluster
       # @return [Hash]
       def self.schema
-        {
+        base = {
           "type" => "object",
           "description" => "Create a cluster of container hosts.",
           "required" => ["name", "cloud", "instance_type", "instance_count"],
@@ -83,6 +83,13 @@ module MU
             }
           }
         }
+        MU::Config::Server.common_properties.keys.each { |k|
+          if !base["properties"][k]
+            base["properties"][k] = MU::Config::Server.common_properties[k].dup
+          end
+        }
+
+        base
       end
 
       # Generic pre-processing of {MU::Config::BasketofKittens::container_clusters}, bare and unvalidated.


### PR DESCRIPTION
Made the auto-generated `server_pool` configurable, mostly so Flatworld could bolt EFS onto the side of it.