### PR TITLE
workaround for deprecated gem option

### DIFF
--- a/cookbooks/mu-master/metadata.rb
+++ b/cookbooks/mu-master/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/cloudamatic/mu'
 issues_url 'https://github.com/cloudamatic/mu/issues'
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '0.9.2'
+version '0.9.3'
 
 %w( centos ).each do |os|
 	supports os

--- a/cookbooks/mu-master/recipes/init.rb
+++ b/cookbooks/mu-master/recipes/init.rb
@@ -399,7 +399,7 @@ end
     package_name "bundler"
     action :upgrade if rubydir == "/usr/local/ruby-current"
     notifies :run, "bash[fix #{rubydir} gem permissions]", :delayed
-    options{'-q --no-documentation'}
+    options('-q --no-documentation')
   end
   execute "#{bundler_path} install" do
     cwd "#{MU_BASE}/lib/modules"
@@ -421,7 +421,7 @@ end
         action :remove
         only_if { ::Dir.exist?(dir) }
         only_if { ::Dir.exist?(gemdir) }
-        options{'-q --no-documentation'}
+        options('-q --no-documentation')
       end
       execute "rm -rf #{gemdir}/knife-windows-#{Regexp.last_match[1]}"
     }

--- a/cookbooks/mu-master/recipes/init.rb
+++ b/cookbooks/mu-master/recipes/init.rb
@@ -399,6 +399,7 @@ end
     package_name "bundler"
     action :upgrade if rubydir == "/usr/local/ruby-current"
     notifies :run, "bash[fix #{rubydir} gem permissions]", :delayed
+    options{'-q --no-documentation'}
   end
   execute "#{bundler_path} install" do
     cwd "#{MU_BASE}/lib/modules"
@@ -420,6 +421,7 @@ end
         action :remove
         only_if { ::Dir.exist?(dir) }
         only_if { ::Dir.exist?(gemdir) }
+        options{'-q --no-documentation'}
       end
       execute "rm -rf #{gemdir}/knife-windows-#{Regexp.last_match[1]}"
     }

--- a/cookbooks/mu-php54/metadata.rb
+++ b/cookbooks/mu-php54/metadata.rb
@@ -8,7 +8,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/cloudamatic/mu'
 issues_url 'https://github.com/cloudamatic/mu/issues'
 chef_version '>= 14.0' if respond_to?(:chef_version)
-version '0.3.0'
+version '0.3.1'
 
 %w( centos ubuntu ).each do |os|
 	supports os

--- a/cookbooks/mu-php54/recipes/default.rb
+++ b/cookbooks/mu-php54/recipes/default.rb
@@ -38,7 +38,9 @@ case node['platform']
 
     # What we really mean is "chef_gem" but that insists on running
     # at compile time, before any of its dependencies are ready.
-    gem_package "mysql"
+    gem_package "mysql" do
+      options{'-q --no-documentation'}
+    end
 
     # Sundry libraries for PHP
     ["libmcrypt", "libmcrypt-devel", "php-devel", "php-pdo", "php-mysql", "php-pgsql", "php-gd", "php-pspell", "php-snmp", "php-xmlrpc", "php-xml", "php-mbstring", "php-mcrypt", "php-pear"].each { |pkg|

--- a/cookbooks/mu-php54/recipes/default.rb
+++ b/cookbooks/mu-php54/recipes/default.rb
@@ -39,7 +39,7 @@ case node['platform']
     # What we really mean is "chef_gem" but that insists on running
     # at compile time, before any of its dependencies are ready.
     gem_package "mysql" do
-      options{'-q --no-documentation'}
+      options('-q --no-documentation')
     end
 
     # Sundry libraries for PHP


### PR DESCRIPTION
the `--no-rdoc` option is deprecated in rubygems 3. workaround for gem installs in chef