### PR TITLE
firewall cookbook: os checks need more universal syntax

### DIFF
--- a/cookbooks/firewall/recipes/default.rb
+++ b/cookbooks/firewall/recipes/default.rb
@@ -23,13 +23,13 @@ firewall 'default' do
 end
 
 # create a variable to use as a condition on some rules that follow
-iptables_firewall = rhel? || node['firewall']['ubuntu_iptables']
+iptables_firewall = platform_family?("rhel") || platform_family?("amazon") || node['firewall']['ubuntu_iptables']
 
 firewall_rule 'allow loopback' do
   interface 'lo'
   protocol :none
   command :allow
-  only_if { linux? && node['firewall']['allow_loopback'] }
+  only_if { node["os"] == "linux" && node['firewall']['allow_loopback'] }
 end
 
 firewall_rule 'allow icmp' do
@@ -43,20 +43,20 @@ end
 firewall_rule 'allow world to ssh' do
   port 22
   source '0.0.0.0/0'
-  only_if { linux? && node['firewall']['allow_ssh'] }
+  only_if { node["os"] == "linux" && node['firewall']['allow_ssh'] }
 end
 
 firewall_rule 'allow world to winrm' do
   port 5989
   source '0.0.0.0/0'
-  only_if { windows? && node['firewall']['allow_winrm'] }
+  only_if { node["os"] == "windows" && node['firewall']['allow_winrm'] }
 end
 
 firewall_rule 'allow world to mosh' do
   protocol :udp
   port 60000..61000
   source '0.0.0.0/0'
-  only_if { linux? && node['firewall']['allow_mosh'] }
+  only_if { node["os"] == "linux" && node['firewall']['allow_mosh'] }
 end
 
 # allow established connections, ufw defaults to this but iptables does not


### PR DESCRIPTION
More runoff from pulling `chef-sugar`, I think. Unclear why this didn't break in initial testing.