### PR TITLE
Tweak cicd for 3.0.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ Docker Build:
   script:
     - docker build -t mu .
     - docker run mu mu-configure --help
-    - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   # only:
   #   - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,7 +236,7 @@ Gen Docs:
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
   script:
     - mu-gen-docs
-    - mv -rf /var/www/html/docs/* public/
+    - mv -f /var/www/html/docs/* public/
   only:
   - master
   - development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,108 +15,108 @@ variables:
   AWS_REGION: us-east-1
   CHEF_LICENSE: "accept"
   
-# .Rubocop:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - rubocop modules/
-#     - rubocop bin/
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Rubocop:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - rubocop modules/
+    - rubocop bin/
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# .Cookstyle:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - cookstyle cookbooks/
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Cookstyle:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - cookstyle cookbooks/
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# Foodcritic:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Foodcritic:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# Foodcritic Deprecations:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Foodcritic Deprecations:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# ChefSpec:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+ChefSpec:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# .Rspec:
-#   stage: Test
-#   before_script:
-#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
-#     - cp spec/azure_creds.tmp spec/azure_creds
-#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
-#     - cp spec/azure_creds.tmp spec/azure_creds
-#     - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-#     - cp spec/mu.yaml.tmp spec/mu.yaml
-#     - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-#     - cp spec/mu.yaml.tmp spec/mu.yaml
-#   script:
-#     - cd modules
-#     - bundle install
-#     - gem install rspec simplecov simplecov-console
-#     - cd ../
-#     - rspec
-#   after_script:
-#     - shred -u spec/azure_creds
-#     - shred -u spec/azure_creds.tmp
-#     - shred -u spec/mu.yaml
-#     - shred -u spec/mu.yaml.tmp
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Rspec:
+  stage: Test
+  before_script:
+    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
+    - cp spec/azure_creds.tmp spec/azure_creds
+    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
+    - cp spec/azure_creds.tmp spec/azure_creds
+    - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+    - cp spec/mu.yaml.tmp spec/mu.yaml
+    - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+    - cp spec/mu.yaml.tmp spec/mu.yaml
+  script:
+    - cd modules
+    - bundle install
+    - gem install rspec simplecov simplecov-console
+    - cd ../
+    - rspec
+  after_script:
+    - shred -u spec/azure_creds
+    - shred -u spec/azure_creds.tmp
+    - shred -u spec/mu.yaml
+    - shred -u spec/mu.yaml.tmp
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# New_Berks:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - apt-get -qq update
-#     - apt-get -qq install git -y
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+New_Berks:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - apt-get -qq update
+    - apt-get -qq install git -y
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
+  except:
+    variables:
+    - $IMAGE_BUILD
   
-# Berks:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - apt-get -qq update
-#     - apt-get -qq install git -y
-#     - rm -rf Berksfile.lock
-#     - berks install
-#     - berks verify
-#     - berks outdated
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Berks:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - apt-get -qq update
+    - apt-get -qq install git -y
+    - rm -rf Berksfile.lock
+    - berks install
+    - berks verify
+    - berks outdated
+  except:
+    variables:
+    - $IMAGE_BUILD
 
 Gem Build:
   stage: Build
@@ -241,7 +241,6 @@ Gen Docs:
   - master
   - development
   - gen_docs
-  - tweak_cicd
   retry: 2
   artifacts:
     paths:
@@ -261,21 +260,19 @@ DockerHub Upload:
     - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
     - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
     - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME mu
-    - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
+    - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PWD
   script:
     - docker tag mu egtlabs/mu:latest
     - docker tag mu egtlabs/mu:$MU_VERSION
     - docker tag mu egtlabs/mu:$MU_VERSION-$OS
     - docker tag mu egtlabs/mu:$OS
+    - docker tag mu egtlabs/mu:development
     - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:latest; fi
     - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:$MU_VERSION; fi
-    - if [ $CI_COMMIT_REF_NAME == "development" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
-    - if [ $CI_COMMIT_REF_NAME == "tweak_cicd" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
-    # - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
+    - if [ $CI_COMMIT_REF_NAME == "development" ]; then  docker push egtlabs/mu:development; fi
   only:
     - master
     - development
-    - tweak_cicd
 
 Upload Gem:
   stage: Deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,6 +166,7 @@ Docker Build:
 
 Docker Test:
   stage: Smoke Test
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   script:
     - mu-configure --help # We should try to come up with a better test than this
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,14 +230,13 @@ Gen Docs:
   stage: Merge/Tag
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   before_script:
-    - mkdir public
+    - mkdir public/
     - mkdir -p /var/www/html/docs
-    - ln -s public /var/www/html/docs
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
   script:
     - mu-gen-docs
-    - ls public
+    - mv -rf /var/www/html/docs/* public/
   only:
   - master
   - development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,9 +160,10 @@ Docker Build:
 Gem Parser Test:
   stage: Smoke Test
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  script:
+  before_script:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address=$myip --google-region=us-east4 --aws-region=us-east-1 --azure-region=eastus
+  script:
     - mu-deploy -d modules/tests/super_simple_bok.yml
     - mu-deploy -d modules/tests/super_complex_bok.yml
   only:
@@ -177,12 +178,11 @@ Gem Parser Test:
 .Mu Install:
   stage: Smoke Test
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+  before_script:
+    - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address=$myip --google-region=us-east4 --aws-region=us-east-1 --azure-region=eastus
   script:
-  - gem install cloud-mu-*.gem
-  - curl https://gist.githubusercontent.com/ryantiger658/87ee6aca72802ce55211a7e6c6bfa76f/raw/aaa54c255936dcb7495b6befeababd44c162922d/.mu.yaml >> /root/.mu.yaml
-  - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-  - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address=$myip --google-region=us-east4 --aws-region=us-east-1 --azure-region=eastus
-  - for cloud in AWS Azure Google; do mu-deploy install/mu-master.yaml -p name=$cloud-MU-$CI_COMMIT_SHORT_SHA -p cloud=$cloud; done
+    - for cloud in AWS Azure Google; do mu-deploy install/mu-master.yaml -p name=$cloud-MU-$CI_COMMIT_SHORT_SHA -p cloud=$cloud; done
   only:
   - master
   - development
@@ -207,11 +207,12 @@ Test Kitchen:
   
 Smoke Test:
   stage: Smoke Test
+  before_script:
+    - apt-get -qq update
+    - apt-get -qq -y install dnsutils
+    - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address=$myip --google-region=us-east4 --aws-region=us-east-1 --azure-region=eastus
   script:
-  - apt-get -qq update
-  - apt-get -qq -y install dnsutils
-  - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-  - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
   - mu-upload-chef-artifacts -sn
   - mu-deploy /opt/mu/var/demo_platform/applications/gitlab-server.yml -p vpc_id=vpc-040da43493f894a8d
   tags: 
@@ -228,19 +229,21 @@ Smoke Test:
 Gen Docs:
   stage: Merge/Tag
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  script:
+  before_script:
+    - mkdir public
+    - mkdir -p /var/www/html/docs
+    - ln -s public /var/www/html/docs
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+  script:
     - mu-gen-docs
-    - pwd
-    - mkdir public
-    - cp -Rf /var/www/html/docs/* public
     - ls public
   only:
   - master
   - development
   - gen_docs
   - tweak_cicd
+  retry: 2
   artifacts:
     paths:
     - public/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,7 +213,6 @@ Gem Parser Test:
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   before_script:
   - export AWS_REGION='us-east-1'
-  - yum install -qy ansible bind-utils
   script:
   - gem install cloud-mu-*.gem
   - curl https://gist.githubusercontent.com/ryantiger658/87ee6aca72802ce55211a7e6c6bfa76f/raw/aaa54c255936dcb7495b6befeababd44c162922d/.mu.yaml >> /root/.mu.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ Gem Parser Test:
     AWS_REGION: us-east-1
   script:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
     - mu-deploy -d modules/tests/super_simple_bok.yml
     - mu-deploy -d modules/tests/super_complex_bok.yml
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,108 +15,108 @@ variables:
   AWS_REGION: us-east-1
   CHEF_LICENSE: "accept"
   
-.Rubocop:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  script:
-    - rubocop modules/
-    - rubocop bin/
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# .Rubocop:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   script:
+#     - rubocop modules/
+#     - rubocop bin/
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-.Cookstyle:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  script:
-    - cookstyle cookbooks/
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# .Cookstyle:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   script:
+#     - cookstyle cookbooks/
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-Foodcritic:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  script:
-    - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Foodcritic:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   script:
+#     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-Foodcritic Deprecations:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  script:
-    - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Foodcritic Deprecations:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   script:
+#     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-ChefSpec:
-  stage: Test
-  image: chef/chefdk:latest
-  script:
-    - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# ChefSpec:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   script:
+#     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-.Rspec:
-  stage: Test
-  before_script:
-    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
-    - cp spec/azure_creds.tmp spec/azure_creds
-    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
-    - cp spec/azure_creds.tmp spec/azure_creds
-    - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-    - cp spec/mu.yaml.tmp spec/mu.yaml
-    - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-    - cp spec/mu.yaml.tmp spec/mu.yaml
-  script:
-    - cd modules
-    - bundle install
-    - gem install rspec simplecov simplecov-console
-    - cd ../
-    - rspec
-  after_script:
-    - shred -u spec/azure_creds
-    - shred -u spec/azure_creds.tmp
-    - shred -u spec/mu.yaml
-    - shred -u spec/mu.yaml.tmp
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# .Rspec:
+#   stage: Test
+#   before_script:
+#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
+#     - cp spec/azure_creds.tmp spec/azure_creds
+#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
+#     - cp spec/azure_creds.tmp spec/azure_creds
+#     - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+#     - cp spec/mu.yaml.tmp spec/mu.yaml
+#     - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+#     - cp spec/mu.yaml.tmp spec/mu.yaml
+#   script:
+#     - cd modules
+#     - bundle install
+#     - gem install rspec simplecov simplecov-console
+#     - cd ../
+#     - rspec
+#   after_script:
+#     - shred -u spec/azure_creds
+#     - shred -u spec/azure_creds.tmp
+#     - shred -u spec/mu.yaml
+#     - shred -u spec/mu.yaml.tmp
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-New_Berks:
-  stage: Test
-  image: chef/chefdk:latest
-  script:
-    - apt-get -qq update
-    - apt-get -qq install git -y
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
-  except:
-    variables:
-    - $IMAGE_BUILD
+# New_Berks:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   script:
+#     - apt-get -qq update
+#     - apt-get -qq install git -y
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
   
-Berks:
-  stage: Test
-  image: chef/chefdk:latest
-  script:
-    - apt-get -qq update
-    - apt-get -qq install git -y
-    - rm -rf Berksfile.lock
-    - berks install
-    - berks verify
-    - berks outdated
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Berks:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   script:
+#     - apt-get -qq update
+#     - apt-get -qq install git -y
+#     - rm -rf Berksfile.lock
+#     - berks install
+#     - berks verify
+#     - berks outdated
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
 Gem Build:
   stage: Build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,7 @@ Docker Build:
   except:
     variables:
     - $IMAGE_BUILD
-  retry: 5
+  retry: 2
 
 Gem Parser Test:
   stage: Smoke Test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,10 +147,11 @@ Docker Build:
     - Gem Build
   before_script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME || true
     - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
     - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
   script:
-    - docker build -t mu .
+    - docker build --cache-from $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME -t mu .
     - docker run mu mu-configure --help
     - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,6 +144,63 @@ Gem Build:
     variables:
     - $IMAGE_BUILD
 
+Docker Build:
+  stage: Docker Build
+  image: docker:stable
+  services:
+    - docker:dind
+  # variables:
+  #   DOCKER_DRIVER: overlay2
+  #   DOCKER_HOST: tcp://docker:2375/
+  dependencies:
+    - Gem Build
+  before_script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
+    - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
+  script:
+    - docker build -t mu .
+    - docker run mu mu-configure --help
+    - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION
+    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION
+    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION-$OS
+    # - docker tag mu $CI_REGISTRY_IMAGE:$OS
+  # only:
+  #   - master
+  #   - development
+  #   - /^gem-.*$/
+  #   - /^cicd-.*$/
+  # except:
+  #   variables:
+  #   - $IMAGE_BUILD
+
+Docker Test:
+  stage: Smoke Test
+  script:
+    - mu-configure --help # We should try to come up with a better test than this
+
+Gem Parser Test:
+  stage: Smoke Test
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+  variables:
+    AWS_REGION: us-east-1
+  script:
+    - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+    - mu-deploy -d modules/tests/super_simple_bok.yml
+    - mu-deploy -d modules/tests/super_complex_bok.yml
+  only:
+    - master
+    - development
+    - /^gem-.*$/
+    - /^cicd-.*$/
+    - tweak_cicd
+  # allow_failure: true
+  # except:
+  #   variables:
+  #   - $IMAGE_BUILD
+
 .Muby Build:
   stage: Build
   image: centos
@@ -156,31 +213,6 @@ Gem Build:
   only:
     - master
     - development
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
-
-Gem Parser Test:
-  stage: Smoke Test
-  before_script: 
-  - export AWS_REGION='us-east-1'
-  script:
-    - apt-get -qq update
-    - apt-get -qq install dnsutils
-    - curl https://gist.githubusercontent.com/ryantiger658/87ee6aca72802ce55211a7e6c6bfa76f/raw/aaa54c255936dcb7495b6befeababd44c162922d/.mu.yaml >> /root/.mu.yaml
-    - gem install cloud-mu-*.gem
-    - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
-    - mu-deploy -d modules/tests/super_simple_bok.yml
-    - mu-deploy -d modules/tests/super_complex_bok.yml
-  dependencies:
-  - Gem Build
-  only:
-    - master
-    - development
-    - /^gem-.*$/
-    - /^cicd-.*$/
   allow_failure: true
   except:
     variables:
@@ -213,13 +245,14 @@ Test Kitchen:
   - echo "export MU_BRANCH=$(CI_COMMIT_REF_NAME)" > ./kitchen_vars
   script:
   - kitchen test mu-install-aws-amazon2 mu-install-aws-centos-7 -c 5
+  after_script:
+  - kitchen destroy
   only:
   - master
   - development
   - gem-mess_with_test_kitchen
-  after_script:
-  - kitchen destroy
-
+  when: manual
+  
 Smoke Test:
   stage: Smoke Test
   before_script: 
@@ -241,112 +274,55 @@ Smoke Test:
     variables:
     - $IMAGE_BUILD
 
-Docker Build:
-  stage: Docker Build
-  services:
-  - docker:dind
-  image: docker:stable
-  variables:
-    DOCKER_DRIVER: overlay2
-    DOCKER_HOST: tcp://docker:2375/
-  dependencies:
-    - Gem Build
-  before_script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-  script:
-    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
-    - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
-    - docker build -t $CI_REGISTRY_IMAGE:latest -t $CI_REGISTRY_IMAGE:$MU_VERSION -t $CI_REGISTRY_IMAGE:$MU_VERSION-$OS -t $CI_REGISTRY_IMAGE:$OS -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
-    - echo "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHA" "$CI_REGISTRY_IMAGE:latest" "$CI_REGISTRY_IMAGE:$MU_VERSION" "$CI_REGISTRY_IMAGE:$MU_VERSION-$OS" "$CI_REGISTRY_IMAGE:$OS" | xargs -n 1 docker push
-    #- docker run my-docker-image /script/to/run/tests
-  only:
-    - master
-    - development
-    - /^gem-.*$/
-    - /^cicd-.*$/
-  except:
-    variables:
-    - $IMAGE_BUILD
-
-DockerTest:
-  stage: Smoke Test
-  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-  script:
-    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
-    - echo "hello from mu $MU_VERSION"
-  only:
-    - master
-    - development
-    - /^gem-.*$/
-    - /^cicd-.*$/
-
-DockerDeploy:
+DockerHub Upload:
   stage: Deploy
   services:
   - docker:dind
   image: docker:stable
-  variables:
-    DOCKER_DRIVER: overlay2
-    DOCKER_HOST: tcp://docker:2375/
+  # variables:
+  #   DOCKER_DRIVER: overlay2
+  #   DOCKER_HOST: tcp://docker:2375/
   when: on_success
-  script:
+  before_script:
     - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
     - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
     - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:latest
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$MU_VERSION
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$MU_VERSION-$OS
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$OS
+    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA mu
     - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
-    - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
+  script:
+    - docker tag mu egtlabs/mu:latest
+    - docker tag mu egtlabs/mu:$MU_VERSION
+    - docker tag mu egtlabs/mu:$MU_VERSION-$OS
+    - docker tag mu egtlabs/mu:$OS
+    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:latest; fi
+    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:$MU_VERSION; fi
+    - if [ $CI_COMMIT_REF_NAME == "development" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
+    - if [ $CI_COMMIT_REF_NAME == "tweak_cicd" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
+    # - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
   only:
     - master
-
-DockerDeploy Manual:
-  stage: Deploy
-  services:
-  - docker:dind
-  image: docker:stable
-  variables:
-    DOCKER_DRIVER: overlay2
-    DOCKER_HOST: tcp://docker:2375/
-  when: manual
-  script:
-    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
-    - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
-    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:latest
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$MU_VERSION
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$MU_VERSION-$OS
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA egtlabs/mu:$OS
-    - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
-    - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
-  only:
-  - development
-  - /^gem-.*$/
-  - /^cicd-.*$/
+    - development
+    - tweak_cicd
 
 Gen Docs:
   stage: Merge/Tag
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   before_script: 
-  - export AWS_REGION='us-east-1'
+    - export AWS_REGION='us-east-1'
   script:
-  - apt-get -qq update
-  - apt-get -qq -y install dnsutils
-  - curl https://gist.githubusercontent.com/ryantiger658/87ee6aca72802ce55211a7e6c6bfa76f/raw/aaa54c255936dcb7495b6befeababd44c162922d/.mu.yaml >> /root/.mu.yaml
-  - gem install cloud-mu-*.gem
-  - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-  - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
-  - mu-gen-docs
-  - mkdir public
-  - cp -Rf /var/www/html/docs/* public
-  - ls public
+    - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+    - mu-gen-docs
+    - mkdir public
+    - cp -Rf /var/www/html/docs/* public
+    - ls public
   dependencies:
   - Gem Build
   only:
   - master
   - development
   - gen_docs
+  - tweak_cicd
   artifacts:
     paths:
     - public/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:2.5
+image: ruby:2.5-slim
 
 stages:
   - Lint Test
@@ -175,23 +175,6 @@ Gem Parser Test:
     variables:
     - $IMAGE_BUILD
 
-.Muby Build:
-  stage: Build
-  image: centos
-  script: 
-    - yum -y groupinstall 'Development Tools'
-    - yum -y install rpm-build
-    - yum-builddep -y extras/ruby_rpm/muby.spec
-    - /usr/bin/rpmbuild -ba extras/ruby_rpm/muby.spec
-    - echo "maybe do something cool and smart here?"
-  only:
-    - master
-    - development
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
-
 .Mu Install:
   stage: Smoke Test
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
@@ -249,13 +232,11 @@ Gen Docs:
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   script:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
-    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
+    - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
     - mu-gen-docs
     - mkdir public
     - cp -Rf /var/www/html/docs/* public
     - ls public
-  dependencies:
-  - Gem Build
   only:
   - master
   - development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,133 +10,127 @@ stages:
   - Merge/Tag
   - Deploy
   
-Rubocop:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - rubocop modules/
-    - rubocop bin/
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Rubocop:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - rubocop modules/
+#     - rubocop bin/
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-Cookstyle:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - cookstyle cookbooks/
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Cookstyle:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - cookstyle cookbooks/
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-Foodcritic:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Foodcritic:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-Foodcritic Deprecations:
-  stage: Lint Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Foodcritic Deprecations:
+#   stage: Lint Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-ChefSpec:
-  stage: Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# ChefSpec:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-.Rspec:
-  stage: Test
-  before_script:
-    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
-    - cp spec/azure_creds.tmp spec/azure_creds
-    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
-    - cp spec/azure_creds.tmp spec/azure_creds
-    - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-    - cp spec/mu.yaml.tmp spec/mu.yaml
-    - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-    - cp spec/mu.yaml.tmp spec/mu.yaml
-  script:
-    - cd modules
-    - bundle install
-    - gem install rspec simplecov simplecov-console
-    - cd ../
-    - rspec
-  after_script:
-    - shred -u spec/azure_creds
-    - shred -u spec/azure_creds.tmp
-    - shred -u spec/mu.yaml
-    - shred -u spec/mu.yaml.tmp
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+# .Rspec:
+#   stage: Test
+#   before_script:
+#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
+#     - cp spec/azure_creds.tmp spec/azure_creds
+#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
+#     - cp spec/azure_creds.tmp spec/azure_creds
+#     - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+#     - cp spec/mu.yaml.tmp spec/mu.yaml
+#     - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+#     - cp spec/mu.yaml.tmp spec/mu.yaml
+#   script:
+#     - cd modules
+#     - bundle install
+#     - gem install rspec simplecov simplecov-console
+#     - cd ../
+#     - rspec
+#   after_script:
+#     - shred -u spec/azure_creds
+#     - shred -u spec/azure_creds.tmp
+#     - shred -u spec/mu.yaml
+#     - shred -u spec/mu.yaml.tmp
+#   allow_failure: true
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
-New_Berks:
-  stage: Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - apt-get -qq update
-    - apt-get -qq install git -y
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
-    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
-  except:
-    variables:
-    - $IMAGE_BUILD
+# New_Berks:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - apt-get -qq update
+#     - apt-get -qq install git -y
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
+#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
   
-Berks:
-  stage: Test
-  image: chef/chefdk:latest
-  variables:
-    CHEF_LICENSE: "accept"
-  script:
-    - apt-get -qq update
-    - apt-get -qq install git -y
-    - rm -rf Berksfile.lock
-    - berks install
-    - berks verify
-    - berks outdated
-  except:
-    variables:
-    - $IMAGE_BUILD
+# Berks:
+#   stage: Test
+#   image: chef/chefdk:latest
+#   variables:
+#     CHEF_LICENSE: "accept"
+#   script:
+#     - apt-get -qq update
+#     - apt-get -qq install git -y
+#     - rm -rf Berksfile.lock
+#     - berks install
+#     - berks verify
+#     - berks outdated
+#   except:
+#     variables:
+#     - $IMAGE_BUILD
 
 Gem Build:
   stage: Build
   script:
     - gem build cloud-mu.gemspec
-  only:
-    - master
-    - development
-    - gen_docs
-    - /^gem-.*$/
-    - /^cicd-.*$/
   artifacts:
     paths:
     - cloud-mu-*.gem

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,9 +143,6 @@ Docker Build:
   image: docker:stable
   services:
     - docker:dind
-  # variables:
-  #   DOCKER_DRIVER: overlay2
-  #   DOCKER_HOST: tcp://docker:2375/
   dependencies:
     - Gem Build
   before_script:
@@ -156,10 +153,7 @@ Docker Build:
     - docker build -t mu .
     - docker run mu mu-configure --help
     - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION
-    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION
-    # - docker tag mu $CI_REGISTRY_IMAGE:$MU_VERSION-$OS
-    # - docker tag mu $CI_REGISTRY_IMAGE:$OS
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   # only:
   #   - master
   #   - development
@@ -168,6 +162,7 @@ Docker Build:
   # except:
   #   variables:
   #   - $IMAGE_BUILD
+  retry: 2
 
 Docker Test:
   stage: Smoke Test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,12 +9,16 @@ stages:
   - Smoke Test
   - Merge/Tag
   - Deploy
+
+variables:
+  DOCKER_DRIVER: overlay
+  AWS_REGION: us-east-1
+  # DOCKER_HOST: tcp://docker:2375/
+  CHEF_LICENSE: "accept"
   
 # Rubocop:
 #   stage: Lint Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - rubocop modules/
 #     - rubocop bin/
@@ -26,8 +30,6 @@ stages:
 # Cookstyle:
 #   stage: Lint Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - cookstyle cookbooks/
 #   allow_failure: true
@@ -38,8 +40,6 @@ stages:
 # Foodcritic:
 #   stage: Lint Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
 #   except:
@@ -49,8 +49,6 @@ stages:
 # Foodcritic Deprecations:
 #   stage: Lint Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
 #   except:
@@ -60,8 +58,6 @@ stages:
 # ChefSpec:
 #   stage: Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
 #   allow_failure: true
@@ -99,8 +95,6 @@ stages:
 # New_Berks:
 #   stage: Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - apt-get -qq update
 #     - apt-get -qq install git -y
@@ -114,8 +108,6 @@ stages:
 # Berks:
 #   stage: Test
 #   image: chef/chefdk:latest
-#   variables:
-#     CHEF_LICENSE: "accept"
 #   script:
 #     - apt-get -qq update
 #     - apt-get -qq install git -y
@@ -160,22 +152,14 @@ Docker Build:
   #   - development
   #   - /^gem-.*$/
   #   - /^cicd-.*$/
-  # except:
-  #   variables:
-  #   - $IMAGE_BUILD
+  except:
+    variables:
+    - $IMAGE_BUILD
   retry: 2
-
-Docker Test:
-  stage: Smoke Test
-  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  script:
-    - mu-configure --help # We should try to come up with a better test than this
 
 Gem Parser Test:
   stage: Smoke Test
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  variables:
-    AWS_REGION: us-east-1
   script:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
@@ -187,10 +171,9 @@ Gem Parser Test:
     - /^gem-.*$/
     - /^cicd-.*$/
     - tweak_cicd
-  # allow_failure: true
-  # except:
-  #   variables:
-  #   - $IMAGE_BUILD
+  except:
+    variables:
+    - $IMAGE_BUILD
 
 .Muby Build:
   stage: Build
@@ -212,8 +195,6 @@ Gem Parser Test:
 .Mu Install:
   stage: Smoke Test
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  before_script:
-  - export AWS_REGION='us-east-1'
   script:
   - gem install cloud-mu-*.gem
   - curl https://gist.githubusercontent.com/ryantiger658/87ee6aca72802ce55211a7e6c6bfa76f/raw/aaa54c255936dcb7495b6befeababd44c162922d/.mu.yaml >> /root/.mu.yaml
@@ -245,8 +226,6 @@ Test Kitchen:
   
 Smoke Test:
   stage: Smoke Test
-  before_script: 
-  - export AWS_REGION='us-east-1'
   script:
   - apt-get -qq update
   - apt-get -qq -y install dnsutils
@@ -264,41 +243,10 @@ Smoke Test:
     variables:
     - $IMAGE_BUILD
 
-DockerHub Upload:
-  stage: Deploy
-  services:
-  - docker:dind
-  image: docker:stable
-  # variables:
-  #   DOCKER_DRIVER: overlay2
-  #   DOCKER_HOST: tcp://docker:2375/
-  when: on_success
-  before_script:
-    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
-    - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
-    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME mu
-    - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
-  script:
-    - docker tag mu egtlabs/mu:latest
-    - docker tag mu egtlabs/mu:$MU_VERSION
-    - docker tag mu egtlabs/mu:$MU_VERSION-$OS
-    - docker tag mu egtlabs/mu:$OS
-    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:latest; fi
-    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:$MU_VERSION; fi
-    - if [ $CI_COMMIT_REF_NAME == "development" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
-    - if [ $CI_COMMIT_REF_NAME == "tweak_cicd" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
-    # - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
-  only:
-    - master
-    - development
-    - tweak_cicd
 
 Gen Docs:
   stage: Merge/Tag
   image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  before_script: 
-    - export AWS_REGION='us-east-1'
   script:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" ---google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" -google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
@@ -320,28 +268,32 @@ Gen Docs:
     variables:
     - $IMAGE_BUILD
 
-.GitHub Pages:
+DockerHub Upload:
   stage: Deploy
-  image: bitnami/git:latest
+  services:
+  - docker:dind
+  image: docker:stable
+  when: on_success
+  before_script:
+    - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
+    - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
+    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME mu
+    - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
   script:
-  - echo "Hello I am going to push to GitHub"
-  - ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-  - git clone git@github.com:cloudamatic/cloudamatic.github.io.git
-  - cp -Rf public/* cloudamatic.github.io
-  - cd cloudamatic.github.io
-  - git status
-  - git add -a
-  - git commit -m "$CI_COMMIT_MESSAGE"
-  - git push origin master
-  dependencies:
-  - Gen Docs
+    - docker tag mu egtlabs/mu:latest
+    - docker tag mu egtlabs/mu:$MU_VERSION
+    - docker tag mu egtlabs/mu:$MU_VERSION-$OS
+    - docker tag mu egtlabs/mu:$OS
+    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:latest; fi
+    - if [ $CI_COMMIT_REF_NAME == "master" ]; then docker push egtlabs/mu:$MU_VERSION; fi
+    - if [ $CI_COMMIT_REF_NAME == "development" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
+    - if [ $CI_COMMIT_REF_NAME == "tweak_cicd" ]; then  docker push egtlabs/mu:$MU_VERSION; fi
+    # - echo "egtlabs/mu:latest" "egtlabs/mu:$MU_VERSION" "egtlabs/mu:$MU_VERSION-$OS" "egtlabs/mu:$OS" | xargs -n 1 docker push
   only:
-  - master
-  - gen_docs
-  allow_failure: true
-  except:
-    variables:
-    - $IMAGE_BUILD
+    - master
+    - development
+    - tweak_cicd
 
 Upload Gem:
   stage: Deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,7 +211,7 @@ Gem Parser Test:
 
 .Mu Install:
   stage: Smoke Test
-  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   before_script:
   - export AWS_REGION='us-east-1'
   script:
@@ -276,8 +276,8 @@ DockerHub Upload:
   before_script:
     - export MU_VERSION=$(grep '\.version' cloud-mu.gemspec | grep -o "'[^']*'" | tr -d "\'")
     - export OS=$(grep 'FROM' Dockerfile | grep -o " [a-zA-Z0-9:]*" | tr -d " " | tr ":" "-")
-    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA mu
+    - docker pull $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
+    - docker tag $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME mu
     - echo $DOCKER_PASS | docker login --username zr2d2 --password-stdin
   script:
     - docker tag mu egtlabs/mu:latest
@@ -296,7 +296,7 @@ DockerHub Upload:
 
 Gen Docs:
   stage: Merge/Tag
-  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+  image: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
   before_script: 
     - export AWS_REGION='us-east-1'
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,6 +240,7 @@ Gen Docs:
   - master
   - development
   - gen_docs
+  - tweak_cicd
   artifacts:
     paths:
     - public/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,111 +13,110 @@ stages:
 variables:
   DOCKER_DRIVER: overlay
   AWS_REGION: us-east-1
-  # DOCKER_HOST: tcp://docker:2375/
   CHEF_LICENSE: "accept"
   
-# Rubocop:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - rubocop modules/
-#     - rubocop bin/
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Rubocop:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - rubocop modules/
+    - rubocop bin/
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# Cookstyle:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - cookstyle cookbooks/
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Cookstyle:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - cookstyle cookbooks/
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# Foodcritic:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Foodcritic:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# Foodcritic Deprecations:
-#   stage: Lint Test
-#   image: chef/chefdk:latest
-#   script:
-#     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Foodcritic Deprecations:
+  stage: Lint Test
+  image: chef/chefdk:latest
+  script:
+    - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# ChefSpec:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+ChefSpec:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# .Rspec:
-#   stage: Test
-#   before_script:
-#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
-#     - cp spec/azure_creds.tmp spec/azure_creds
-#     - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
-#     - cp spec/azure_creds.tmp spec/azure_creds
-#     - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-#     - cp spec/mu.yaml.tmp spec/mu.yaml
-#     - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
-#     - cp spec/mu.yaml.tmp spec/mu.yaml
-#   script:
-#     - cd modules
-#     - bundle install
-#     - gem install rspec simplecov simplecov-console
-#     - cd ../
-#     - rspec
-#   after_script:
-#     - shred -u spec/azure_creds
-#     - shred -u spec/azure_creds.tmp
-#     - shred -u spec/mu.yaml
-#     - shred -u spec/mu.yaml.tmp
-#   allow_failure: true
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+.Rspec:
+  stage: Test
+  before_script:
+    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_ID__/${AZURE_CLIENT_ID}/" > spec/azure_creds.tmp
+    - cp spec/azure_creds.tmp spec/azure_creds
+    - cat spec/azure_creds | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/azure_creds.tmp
+    - cp spec/azure_creds.tmp spec/azure_creds
+    - cat spec/mu.yaml | sed -e "s/__AZURE_DIRECTORY_ID__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+    - cp spec/mu.yaml.tmp spec/mu.yaml
+    - cat spec/mu.yaml | sed -e "s/__AZURE_CLIENT_SECRET__/${AZURE_CLIENT_SECRET}/" > spec/mu.yaml.tmp
+    - cp spec/mu.yaml.tmp spec/mu.yaml
+  script:
+    - cd modules
+    - bundle install
+    - gem install rspec simplecov simplecov-console
+    - cd ../
+    - rspec
+  after_script:
+    - shred -u spec/azure_creds
+    - shred -u spec/azure_creds.tmp
+    - shred -u spec/mu.yaml
+    - shred -u spec/mu.yaml.tmp
+  allow_failure: true
+  except:
+    variables:
+    - $IMAGE_BUILD
 
-# New_Berks:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - apt-get -qq update
-#     - apt-get -qq install git -y
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
-#     - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+New_Berks:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - apt-get -qq update
+    - apt-get -qq install git -y
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Installing $d" && cd "cookbooks/$d" && berks install); done
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Verifying $d" && cd "cookbooks/$d" && berks verify); done
+    - for d in `ls -1 ./cookbooks | grep -v '^firewall$'` ; do (echo && echo "Analyzing $d" && cd "cookbooks/$d" && berks outdated); done
+  except:
+    variables:
+    - $IMAGE_BUILD
   
-# Berks:
-#   stage: Test
-#   image: chef/chefdk:latest
-#   script:
-#     - apt-get -qq update
-#     - apt-get -qq install git -y
-#     - rm -rf Berksfile.lock
-#     - berks install
-#     - berks verify
-#     - berks outdated
-#   except:
-#     variables:
-#     - $IMAGE_BUILD
+Berks:
+  stage: Test
+  image: chef/chefdk:latest
+  script:
+    - apt-get -qq update
+    - apt-get -qq install git -y
+    - rm -rf Berksfile.lock
+    - berks install
+    - berks verify
+    - berks outdated
+  except:
+    variables:
+    - $IMAGE_BUILD
 
 Gem Build:
   stage: Build
@@ -147,15 +146,16 @@ Docker Build:
     - docker run mu mu-configure --help
     - docker tag mu $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME
-  # only:
-  #   - master
-  #   - development
-  #   - /^gem-.*$/
-  #   - /^cicd-.*$/
+  only:
+    - master
+    - development
+    - /^gem-.*$/
+    - /^cicd-.*$/
+    - /^docker-.*$/
   except:
     variables:
     - $IMAGE_BUILD
-  retry: 2
+  retry: 5
 
 Gem Parser Test:
   stage: Smoke Test
@@ -170,7 +170,6 @@ Gem Parser Test:
     - development
     - /^gem-.*$/
     - /^cicd-.*$/
-    - tweak_cicd
   except:
     variables:
     - $IMAGE_BUILD
@@ -204,7 +203,6 @@ Test Kitchen:
   only:
   - master
   - development
-  - gem-mess_with_test_kitchen
   when: manual
   
 Smoke Test:
@@ -234,6 +232,7 @@ Gen Docs:
     - myip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
     - mu-configure -n --aws-access-key="${AWS_ACCESS_KEY_ID}" --aws-access-secret="${AWS_SECRET_ACCESS_KEY}" --azure-directory-id="${AZURE_DIRECTORY_ID}" --azure-client-id="${AZURE_CLIENT_ID}" --azure-client-secret="${AZURE_CLIENT_SECRET}" --azure-subscription="${AZURE_SUBSCIPTION_ID}" --mu-admin-email="egt-labs-dev@eglobaltech.com" --public-address="${myip}" --google-credentials-encoded="${GOOGLE_CREDS_ENCODED}" --google-region=us-east4 --google-project="egt-labs-admin" --aws-region=us-east-1 --azure-region=eastus
     - mu-gen-docs
+    - pwd
     - mkdir public
     - cp -Rf /var/www/html/docs/* public
     - ls public
@@ -241,7 +240,6 @@ Gen Docs:
   - master
   - development
   - gen_docs
-  - tweak_cicd
   artifacts:
     paths:
     - public/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./cloud-mu-*.gem /root
 EXPOSE 2260
 
 RUN apt-get update
-RUN apt-get install -y ruby2.5-dev g++ dnsutils ansible
+RUN apt-get install -y make ruby2.5-dev g++ dnsutils ansible
 RUN gem install ./cloud-mu-*.gem thin -N
 RUN mkdir -p /opt/mu/etc/
 RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5-slim
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./cloud-mu-*.gem /root
 EXPOSE 2260
 
 RUN apt-get update
-RUN apt-get install -y ruby2.5-dev g++
+RUN apt-get install -y ruby2.5-dev g++ dig
 RUN gem install ./cloud-mu-*.gem thin -N
 RUN mkdir -p /opt/mu/etc/
 RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ COPY ./cloud-mu-*.gem /root
 
 EXPOSE 2260
 
-RUN apt-get update
-RUN apt-get install -y make ruby2.5-dev g++ dnsutils ansible
-RUN gem install ./cloud-mu-*.gem thin -N
 RUN mkdir -p /opt/mu/etc/
 RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/
+RUN apt-get install -y build-essential ruby2.5-dev g++ dnsutils ansible
+RUN apt-get update
+RUN gem install ./cloud-mu-*.gem thin -N
 RUN rm cloud-mu-*.gem
-RUN apt-get remove -y make g++
+RUN apt-get remove -y make g++ build-essential
 CMD /usr/sbin/init

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./cloud-mu-*.gem /root
 EXPOSE 2260
 
 RUN apt-get update
-RUN apt-get install -y ruby2.5-dev g++ bind-utils
+RUN apt-get install -y ruby2.5-dev g++ dnsutils ansible
 RUN gem install ./cloud-mu-*.gem thin -N
 RUN mkdir -p /opt/mu/etc/
 RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./cloud-mu-*.gem /root
 EXPOSE 2260
 
 RUN apt-get update
-RUN apt-get install -y ruby2.5-dev g++ dig
+RUN apt-get install -y ruby2.5-dev g++ bind-utils
 RUN gem install ./cloud-mu-*.gem thin -N
 RUN mkdir -p /opt/mu/etc/
 RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,25 @@
 FROM ruby:2.5-slim
 
-WORKDIR /root
+RUN mkdir -p /opt/mu/etc/ /home/mu /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/
 
-COPY ./cloud-mu-*.gem /root
+WORKDIR /home/mu
+
+RUN apt-get update
+
+RUN apt-get install -y ruby2.5-dev dnsutils ansible build-essential
+
+RUN apt-get upgrade -y
+
+COPY ./cloud-mu-*.gem /home/mu
+
+RUN gem install ./cloud-mu-*.gem thin -N
+
+RUN rm cloud-mu-*.gem
+
+RUN apt-get remove -y build-essential ruby2.5-dev
+
+RUN apt-get autoremove -y
 
 EXPOSE 2260
 
-RUN mkdir -p /opt/mu/etc/
-RUN mkdir -p /usr/local/ruby-current/lib/ruby/gems/2.5.0/gems/var/
-RUN apt-get install -y build-essential ruby2.5-dev g++ dnsutils ansible
-RUN apt-get update
-RUN gem install ./cloud-mu-*.gem thin -N
-RUN rm cloud-mu-*.gem
-RUN apt-get remove -y make g++ build-essential
 CMD /usr/sbin/init

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 mu -- Cloudamatic Automation Tooling
 ===
 [![pipeline status](https://gitlab.com/cloudamatic/mu/badges/master/pipeline.svg)](https://gitlab.com/cloudamatic/mu/commits/master)
-[![Gem Version](https://badge.fury.io/rb/cloud-mu.svg)](https://badge.fury.io/rb/cloud-mu)
 [![Maintainability](https://api.codeclimate.com/v1/badges/dd4e5d867890336accd1/maintainability)](https://codeclimate.com/github/cloudamatic/mu/maintainability)
-[![Inline docs](http://inch-ci.org/github/cloudamatic/mu.svg?branch=master)](http://inch-ci.org/github/cloudamatic/mu)
+[![Gem Version](https://badge.fury.io/rb/cloud-mu.svg)](https://badge.fury.io/rb/cloud-mu)
+[![Docker Version](https://images.microbadger.com/badges/version/egtlabs/mu.svg)](https://microbadger.com/images/egtlabs/mu)
 
 # About mu
 **Mu**  is the deployer and developer toolset for the Cloudamatic suite of services, designed to provision, orchestrate and manage complex platforms and applications. At [eGT Labs](https://www.eglobaltech.com/egt-labs/), we use mu for rapid prototyping of cloud migration efforts for federal customers, for managing cloud applications throughout their lifecycles, and as a tools library for cloud maintenance tasks.


### PR DESCRIPTION
CICD QOL Improvements
----------------------------

- Switched the docker base image to `ruby:2.5-slim` to decrease image size
- Moved the Parser test, and the docs generation into the newly built docker images
- Cleaned up syntax in the CI/CD pipeline
- Reordered the pipeline for speed improvements
- Restructured Dockerfile to leverage layer caching