### PR TITLE
Google polish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   
 .Rubocop:
   stage: Lint Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - rubocop modules/
     - rubocop bin/
@@ -28,7 +28,7 @@ variables:
 
 .Cookstyle:
   stage: Lint Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - cookstyle cookbooks/
   allow_failure: true
@@ -38,7 +38,7 @@ variables:
 
 Foodcritic:
   stage: Lint Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - foodcritic cookbooks/ -t ~FC075 -t ~FC015 -t ~FC034 -t ~FC122 -X firewall/*
   except:
@@ -47,7 +47,7 @@ Foodcritic:
 
 Foodcritic Deprecations:
   stage: Lint Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - foodcritic cookbooks/ -t deprecated -t chef13 -t chef14 -t chef15 -X cokbooks/firewall/*
   except:
@@ -56,7 +56,7 @@ Foodcritic Deprecations:
 
 ChefSpec:
   stage: Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - for d in ./cookbooks/*/ ; do (cd "$d" && chef exec rspec); done
   allow_failure: true
@@ -93,7 +93,7 @@ ChefSpec:
 
 New_Berks:
   stage: Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - apt-get -qq update
     - apt-get -qq install git -y
@@ -106,7 +106,7 @@ New_Berks:
   
 Berks:
   stage: Test
-  image: chef/chefdk:latest
+  image: chef/chefdk:4.5
   script:
     - apt-get -qq update
     - apt-get -qq install git -y
@@ -193,7 +193,7 @@ Gem Parser Test:
 
 Test Kitchen:
   stage: Smoke Test
-  image: chef/chefdk:latest
+  image: chef/chefdk::4.5
   before_script:
   - echo "export MU_BRANCH=$(CI_COMMIT_REF_NAME)" > ./kitchen_vars
   script:

--- a/bin/mu-configure
+++ b/bin/mu-configure
@@ -804,7 +804,7 @@ if !$NOOP
   # Converts the current $CONFIGURABLES object to a Hash suitable for merging
   # with $MU_CFG.
   def setConfigTree(tree = $CONFIGURABLES)
-    cfg = {}
+    cfg = $MU_CFG.nil? ? {} : $MU_CFG.dup
     tree.each_pair { |key, data|
       next if !AMROOT and data['rootonly']
       if data.has_key?("subtree")

--- a/bin/mu-configure
+++ b/bin/mu-configure
@@ -107,6 +107,12 @@ $CONFIGURABLES = {
     "desc" => "The local system's value for HOSTNAME",
     "changes" => ["chefrun", "hostname"]
   },
+  "disable_mommacat" => {
+    "title" => "Disable Momma Cat",
+    "default" => false,
+    "desc" => "Disable the Momma Cat grooming daemon. Nodes which require asynchronous Ansible/Chef bootstraps will not function. This option is only honored in gem-based installations.",
+    "boolean" => true
+  },
   "mommacat_port" => {
     "title" => "Momma Cat Listen Port",
     "pattern" => /^[0-9]+$/i,

--- a/cloud-mu.gemspec
+++ b/cloud-mu.gemspec
@@ -17,8 +17,8 @@ end
 
 Gem::Specification.new do |s|
   s.name        = 'cloud-mu'
-  s.version     = '3.0.1'
-  s.date        = '2019-11-22'
+  s.version     = '3.0.2'
+  s.date        = '2019-12-03'
   s.require_paths = ['modules']
   s.required_ruby_version = '>= 2.4'
   s.summary     = "The eGTLabs Mu toolkit for unified cloud deployments"
@@ -59,4 +59,6 @@ EOF
   s.add_runtime_dependency 'addressable', '~> 2.5'
   s.add_runtime_dependency 'slack-notifier', "~> 2.3"
   s.add_runtime_dependency 'azure_sdk', "~> 0.37"
+  s.add_runtime_dependency 'rack', "~> 2.0"
+  s.add_runtime_dependency 'thin', "~> 1.7"
 end

--- a/modules/Gemfile
+++ b/modules/Gemfile
@@ -14,33 +14,13 @@
 
 source "https://rubygems.org"
 gemspec :path => "../", :name => "cloud-mu"
-#gem 'yard'
-#gem 'ruby-graphviz', "~> 1.2.3"
-#gem "aws-sdk-core", "< 3"  
-#gem 'chronic_duration', "~> 0.10.6"
-#gem 'simple-password-gen'
-#gem 'optimist'
-#gem 'json-schema'
-#gem 'colorize'
-#gem 'color'
-gem 'rack'
-gem 'thin'
 gem 'berkshelf', '~> 7.0'
 gem 'mysql2'
 gem 'ruby-wmi'
 gem 'chef-vault', "~> 3.4"
-#gem 'netaddr', '~> 2.0.3'
-#gem 'nokogiri', "~> 1.8.4"
-#gem 'solve', '~> 4.0.0'
-#gem 'net-ldap'
-#gem 'googleauth', "~> 0.6.6"
-#gem 'google-api-client', "~> 0.25.0"
 gem 'chef-sugar'
 gem 'ffi-libarchive' # needed to keep berkshelf from breaking on Mac tarballs
 gem 'winrm', '~> 2.3', '>= 2.3.2'
 gem 'knife-windows', :git => "https://github.com/eGT-Labs/knife-windows.git", :branch => "winrm_cert_auth"
-#gem 'rubocop', '~> 0.58.2'
 gem 'foodcritic', '~> 14.1.0'
-#gem 'addressable', '~> 2.5.2'
 gem 'chef-dk', '~> 3.2.30'
-#gem 'slack-notifier'

--- a/modules/mu/cloud.rb
+++ b/modules/mu/cloud.rb
@@ -1381,8 +1381,16 @@ module MU
             if !@config['vpc']["id"].nil? and @config['vpc']["id"].is_a?(Hash)
               @config['vpc']["id"] = MU::Config::Ref.new(@config['vpc']["id"])
             end
-            if !@config['vpc']["id"].nil? and @config['vpc']["id"].is_a?(MU::Config::Ref) and !@config['vpc']["id"].kitten.nil?
-              @vpc = @config['vpc']["id"].kitten
+            if !@config['vpc']["id"].nil?
+              if @config['vpc']["id"].is_a?(MU::Config::Ref) and !@config['vpc']["id"].kitten.nil?
+                @vpc = @config['vpc']["id"].kitten
+              else
+                if @config['vpc']['habitat']
+                  @config['vpc']['habitat'] = MU::Config::Ref.get(@config['vpc']['habitat'])
+                end
+                vpc_ref = MU::Config::Ref.get(@config['vpc'])
+                @vpc = vpc_ref.kitten
+              end
             elsif !@config['vpc']["name"].nil? and @deploy
               MU.log "Attempting findLitterMate on VPC for #{self}", loglevel, details: @config['vpc']
 

--- a/modules/mu/cloud.rb
+++ b/modules/mu/cloud.rb
@@ -2054,6 +2054,15 @@ puts "CHOOSING #{@vpc.to_s} 'cause it has #{@config['vpc']['subnet_name']}"
               cloudclass.cleanup(params)
             rescue MuCloudResourceNotImplemented
               MU.log "No #{cloud} implementation of #{shortname}.cleanup, skipping", MU::DEBUG, details: flags
+            rescue Exception => e
+              in_msg = cloud
+              if params and params[:region]
+                in_msg += " "+params[:region]
+              end
+              if params and params[:flags] and params[:flags]["project"]
+                in_msg += " project "+params[:flags]["project"]
+              end
+              MU.log "Skipping #{shortname} cleanup method in #{in_msg} due to exception: #{e.message}", MU::WARN
             end
           }
           MU::MommaCat.unlockAll

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -165,8 +165,8 @@ module MU
 
         # blow up if this resource *has* to live in a project
         if cloudobj.cloudclass.canLiveIn == [:Habitat]
-          MU.log "Failed to find project for cloudobj of class #{cloudobj.cloudclass.class.name}", MU::ERR, details: cloudobj
-          raise MuError, "Failed to find project for cloudobj of class #{cloudobj.cloudclass.class.name}"
+          MU.log "Failed to find project for cloudobj #{cloudobj.to_s}", MU::ERR, details: cloudobj
+          raise MuError, "Failed to find project for cloudobj #{cloudobj.to_s}"
         end
 
         nil

--- a/modules/mu/clouds/google.rb
+++ b/modules/mu/clouds/google.rb
@@ -816,6 +816,10 @@ MU.log e.message, MU::WARN, details: e.inspect
       def self.admin_directory(subclass = nil, credentials: nil)
         require 'google/apis/admin_directory_v1'
 
+        # fill in the default credential set name so we don't generate
+        # dopey extra warnings about falling back on scopes
+        credentials ||= MU::Cloud::Google.credConfig(credentials, name_only: true)
+
         writescopes = ['admin.directory.group.member', 'admin.directory.group', 'admin.directory.user', 'admin.directory.domain', 'admin.directory.orgunit', 'admin.directory.rolemanagement', 'admin.directory.customer', 'admin.directory.user.alias', 'admin.directory.userschema']
         readscopes = ['admin.directory.group.member.readonly', 'admin.directory.group.readonly', 'admin.directory.user.readonly', 'admin.directory.domain.readonly', 'admin.directory.orgunit.readonly', 'admin.directory.rolemanagement.readonly', 'admin.directory.customer.readonly', 'admin.directory.user.alias.readonly', 'admin.directory.userschema.readonly']
         @@readonly_semaphore.synchronize {

--- a/modules/mu/clouds/google/container_cluster.rb
+++ b/modules/mu/clouds/google/container_cluster.rb
@@ -1044,6 +1044,9 @@ module MU
               "credentials" => cluster["credentials"],
               "type" => "service"
             }
+            if user["name"].length < 6
+              user["name"] += Password.pronounceable(6)
+            end
             configurator.insertKitten(user, "users", true)
             cluster['dependencies'] ||= []
             cluster['service_account'] = MU::Config::Ref.get(

--- a/modules/mu/clouds/google/firewall_rule.rb
+++ b/modules/mu/clouds/google/firewall_rule.rb
@@ -45,8 +45,17 @@ module MU
         def create
           @cloud_id = @mu_name.downcase.gsub(/[^-a-z0-9]/, "-")
 
-          vpc_id = @vpc.url if !@vpc.nil?
-          vpc_id ||= @config['vpc']['vpc_id'] if @config['vpc'] and @config['vpc']['vpc_id']
+          vpc_id = if @vpc
+            @vpc.url if !@vpc.nil?
+          else
+            vpc_ref = MU::Config::Ref.get(@config['vpc'])
+            if !vpc_ref.kitten
+              MU.log "Failed to resolve VPC for FirewallRule #{@mu_name}", MU::ERR, details: @config['vpc']
+              raise MuError, "Failed to resolve VPC for FirewallRule #{@mu_name}"
+            else
+              vpc_ref.kitten.url
+            end
+          end
 
           if vpc_id.nil?
             raise MuError, "Failed to resolve VPC for #{self}"
@@ -419,10 +428,15 @@ end
         # @return [Boolean]: True if validation succeeded, False otherwise
         def self.validateConfig(acl, config)
           ok = true
-          acl['project'] ||= MU::Cloud::Google.defaultProject(acl['credentials'])
 
           if acl['vpc']
-            acl['vpc']['project'] ||= acl['project']
+            if !acl['vpc']['habitat']
+              acl['vpc']['project'] ||= acl['project']
+            elsif acl['vpc']['habitat'] and acl['vpc']['habitat']['id']
+              acl['vpc']['project'] = acl['vpc']['habitat']['id']
+            elsif acl['vpc']['habitat'] and acl['vpc']['habitat']['name']
+              acl['vpc']['project'] = acl['vpc']['habitat']['name']
+            end
             correct_vpc = MU::Cloud::Google::VPC.pickVPC(
               acl['vpc'],
               acl,

--- a/modules/mu/clouds/google/firewall_rule.rb
+++ b/modules/mu/clouds/google/firewall_rule.rb
@@ -423,12 +423,13 @@ end
 
           if acl['vpc']
             acl['vpc']['project'] ||= acl['project']
-            acl['vpc'] = MU::Cloud::Google::VPC.pickVPC(
+            correct_vpc = MU::Cloud::Google::VPC.pickVPC(
               acl['vpc'],
               acl,
               "firewall_rule",
               config
             )
+            acl['vpc'] = correct_vpc if correct_vpc
           end
 
           acl['rules'] ||= []

--- a/modules/mu/clouds/google/server.rb
+++ b/modules/mu/clouds/google/server.rb
@@ -1424,6 +1424,9 @@ next if !create
               "credentials" => server["credentials"],
               "type" => "service"
             }
+            if user["name"].length < 6
+              user["name"] += Password.pronounceable(6)
+            end
             if server['roles']
               user['roles'] = server['roles'].dup
             end
@@ -1432,13 +1435,13 @@ next if !create
             server['service_account'] = MU::Config::Ref.get(
               type: "users",
               cloud: "Google",
-              name: server["name"],
-              project: server["project"],
-              credentials: server["credentials"]
+              name: user["name"],
+              project: user["project"],
+              credentials: user["credentials"]
             )
             server['dependencies'] << {
               "type" => "user",
-              "name" => server["name"]
+              "name" => user["name"]
             }
           end
 

--- a/modules/mu/clouds/google/server_pool.rb
+++ b/modules/mu/clouds/google/server_pool.rb
@@ -380,6 +380,9 @@ start = Time.now
               "credentials" => pool["credentials"],
               "type" => "service"
             }
+            if user["name"].length < 6
+              user["name"] += Password.pronounceable(6)
+            end
             configurator.insertKitten(user, "users", true)
             pool['dependencies'] ||= []
             pool['service_account'] = MU::Config::Ref.get(

--- a/modules/mu/config.rb
+++ b/modules/mu/config.rb
@@ -1972,6 +1972,13 @@ $CONFIGURABLES
 
     # Namespace magic to pass to ERB's result method.
     def get_binding(keyset)
+      environment = $environment
+      myPublicIp = $myPublicIp
+      myRoot = $myRoot
+      myAZ = $myAZ
+      myRegion = $myRegion
+      myAppName = $myAppName
+
 #      return MU::Config.global_bindings[keyset] if MU::Config.global_bindings[keyset]
       MU::Config.global_bindings[keyset] = binding
       MU::Config.global_bindings[keyset]

--- a/modules/mu/config.rb
+++ b/modules/mu/config.rb
@@ -525,7 +525,7 @@ end
               region: @region,
               habitats: hab_arg,
               credentials: @credentials,
-              dummy_ok: (["habitats", "folders", "users", "groups"].include?(@type))
+              dummy_ok: (["habitats", "folders", "users", "groups", "vpcs"].include?(@type))
             )
             @obj ||= found.first if found
           rescue ThreadError => e
@@ -1786,6 +1786,9 @@ $CONFIGURABLES
 
 
       acl = {"name" => name, "rules" => rules, "vpc" => realvpc, "cloud" => cloud, "admin" => true, "credentials" => credentials }
+      if cloud == "Google" and acl["vpc"] and acl["vpc"]["habitat"]
+        acl['project'] = acl["vpc"]["habitat"]["id"] || acl["vpc"]["habitat"]["name"]
+      end
       acl.delete("vpc") if !acl["vpc"]
       if !resclass.isGlobal? and !region.nil? and !region.empty?
         acl["region"] = region

--- a/modules/mu/mommacat.rb
+++ b/modules/mu/mommacat.rb
@@ -2762,6 +2762,9 @@ MESSAGE_END
 		# Start the Momma Cat daemon and return the exit status of the command used
     # @return [Integer]
     def self.start
+      if MU.inGem? and MU.muCfg['disable_mommacat']
+        return
+      end
       base = (Process.uid == 0 and !MU.localOnly) ? "/var" : MU.dataDir
       [base, "#{base}/log", "#{base}/run"].each { |dir|
        if !Dir.exist?(dir)
@@ -2808,6 +2811,9 @@ MESSAGE_END
     # Return true if the Momma Cat daemon appears to be running
     # @return [Boolean]
     def self.status
+      if MU.inGem? and MU.muCfg['disable_mommacat']
+        return true
+      end
       if File.exist?(daemonPidFile)
         pid = File.read(daemonPidFile).chomp.to_i
         begin

--- a/modules/mu/mommacat.rb
+++ b/modules/mu/mommacat.rb
@@ -2784,20 +2784,19 @@ MESSAGE_END
 
       MU.log cmd, MU::NOTICE
 
-      output = %x{#{cmd}}
-
-      Dir.chdir(origdir)
-
       retries = 0
       begin
+        output = %x{#{cmd}}
         sleep 1
         retries += 1
         if retries >= 10
-          MU.log "MommaCat failed to start (command was #{cmd})", MU::WARN, details: output
+          MU.log "MommaCat failed to start (command was #{cmd}, working directory #{MU.myRoot}/modules)", MU::WARN, details: output
           pp caller
           return $?.exitstatus
         end
       end while !status
+
+      Dir.chdir(origdir)
     
       if $?.exitstatus != 0
         exit 1


### PR DESCRIPTION
Quality of Life enhancements
--------------------------------
* Quieter messaging when falling back to read-only scopes in GSuite environments
* BoK default variables like `$environment` are now also bound to the obvious local variable name (e.g. `environment`)
* Cope more gracefully when cloud implementations of `.cleanup` throw errors

Bugfixes
---------
* Don't overwrite pre-existing `~/.mu.yaml` stubs when initializing a new gem installation
* Pad too-short GCP service account names when generating `User` resources automatically
* `Google::FirewallRule`: correct some behaviors around shared VPCs and admin default firewall rules